### PR TITLE
Fix API proxy prefix in dev

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -9,7 +9,8 @@ export default defineConfig({
       '/api': {
         target: 'https://aiventa-crm.onrender.com',
         changeOrigin: true,
-        rewrite: (path) => path.replace(/^\/api/, ''),
+        // Keep the /api prefix when forwarding requests so backend routes match
+        // the expected /api/* paths.
       },
     },
   },


### PR DESCRIPTION
## Summary
- keep `/api` prefix when proxying dev requests

## Testing
- `npm run lint --if-present` *(fails: cannot find package `@eslint/js`)*

------
https://chatgpt.com/codex/tasks/task_e_685b36419b1c8322be5636cb66151208