### PR TITLE
Add GET /floor-traffic alias

### DIFF
--- a/routes/floorTraffic.js
+++ b/routes/floorTraffic.js
@@ -18,6 +18,20 @@ router.get('/floor-traffic/today', async (req, res, next) => {
 });
 
 /**
+ * GET /api/floor-traffic
+ * Alias for today's floor-traffic entries.
+ * Mirrors the FastAPI implementation.
+ */
+router.get('/floor-traffic', async (req, res, next) => {
+  try {
+    const todayLogs = await FloorTrafficModel.findToday();
+    return res.json(todayLogs);
+  } catch (err) {
+    return next(err);
+  }
+});
+
+/**
  * POST /api/floor-traffic
  * Create a new floor-traffic entry.
  */


### PR DESCRIPTION
## Summary
- add GET `/floor-traffic` route that returns today's logs

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685b3628852483228f333758d7b3a34c