### PR TITLE
Update FastAPI setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,16 @@
 
 ### FastAPI (Python)
 
+From the project root:
+
 ```bash
-cd backend
 python3 -m venv venv
 source venv/bin/activate
-pip install -r ../requirements.txt
+pip install -r requirements.txt
 uvicorn app.main:app --reload --port 8000
 ```
+
+The `backend/` folder is obsolete and not used.
 
 ### Express (Node.js)
 


### PR DESCRIPTION
## Summary
- update README to remove `cd backend`
- provide setup commands from the project root
- note that `backend/` is obsolete

## Testing
- `npm test` *(fails: missing script)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_685b3d56650c8322bbe01a1ae27160f8