### PR TITLE
Remove prefix from floor traffic router

### DIFF
--- a/app/routers/floor_traffic.py
+++ b/app/routers/floor_traffic.py
@@ -4,10 +4,7 @@ from datetime import date, datetime, timedelta
 from app.db import supabase
 from app.models import FloorTrafficCustomer, FloorTrafficCustomerCreate
 
-router = APIRouter(
-    prefix="/api/floor-traffic",
-    tags=["floor-traffic"],
-)
+router = APIRouter()
 
 @router.get(
     "/today",


### PR DESCRIPTION
## Summary
- simplify `floor_traffic` router by removing internal prefix
- keep router mounted in `main.py` with prefix/tags

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685b3fbaf97883228b0505bfa0fcf370