### PR TITLE
Fix Tailwind config export

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,6 @@
-module.exports = {
+export default {
   content: ["./frontend/src/**/*.{js,jsx,ts,tsx}"],
+  darkMode: 'media', // respect OS setting; or 'class' to toggle manually
   theme: {
     extend: {
       colors: {
@@ -12,14 +13,4 @@ module.exports = {
     },
   },
   plugins: [],
-}
-export default {
-  // or module.exports = { … } if you’re not using ESM
-  darkMode: 'media', // respect OS setting; or 'class' to toggle manually
-  theme: {
-    extend: {
-      // …your custom colors, offwhite, etc…
-    }
-  },
-  plugins: []
 }


### PR DESCRIPTION
## Summary
- remove duplicate export in `tailwind.config.js`
- keep single ESM style configuration

## Testing
- `npm run build` *(fails: `vite: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685b44f4ce488322928aa0634c7d8a12