### PR TITLE
Configure CORS via env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,9 @@ available. Create a `.env` file in the project root:
 ```env
 SUPABASE_URL=<your-supabase-url>
 SUPABASE_KEY=<your-supabase-key>
+CORS_ORIGINS=https://aiventa-crm.vercel.app
 ```
 
-The Express server reads `CORS_ORIGIN` and `PORT` if you wish to
-customize the allowed frontend origin or port number.
+Both API servers read `CORS_ORIGINS` (comma separated) to control which
+domains may access the APIs. Set it to your deployed frontend URL.  They
+also respect `PORT` if you wish to customize the port number.

--- a/app/main.py
+++ b/app/main.py
@@ -1,6 +1,7 @@
 # app/main.py
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+import os
 from fastapi.staticfiles import StaticFiles
 
 from app.routers.leads           import router as leads_router
@@ -13,10 +14,12 @@ from app.routers.activities      import router as activities_router
 
 app = FastAPI(title="aiVenta CRM API")
 
-# 1️⃣ CORS: allow your Vercel front-end
+# 1️⃣ CORS: allow origins from env or default to production domain
+origins_env = os.environ.get("CORS_ORIGINS", "https://aiventa-crm.vercel.app")
+allowed_origins = [o.strip() for o in origins_env.split(",") if o.strip()]
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["https://aiventa-crm.vercel.app"],  # production URL
+    allow_origins=allowed_origins,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,14 +1,17 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+import os
 from .routers.leads import router as leads_router
 from .routers.users import router as users_router
 
 app = FastAPI(title="Aiventa CRM API")
 
+origins_env = os.environ.get("CORS_ORIGINS", "https://aiventa-crm.vercel.app")
+allowed_origins = [o.strip() for o in origins_env.split(",") if o.strip()]
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],      # wildcard allows all origins
-    allow_credentials=False,  # must be False when using wildcard
+    allow_origins=allowed_origins,
+    allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],
 )

--- a/index.js
+++ b/index.js
@@ -5,9 +5,11 @@ import floorTrafficRouter from './routes/floorTraffic.js';
 
 const app = express();
 
-// Allow requests from your frontend (adjust origin as needed)
+// Allow requests from configured origins
+const originsEnv = process.env.CORS_ORIGINS || 'https://aiventa-crm.vercel.app';
+const allowedOrigins = originsEnv.split(',').map(o => o.trim()).filter(Boolean);
 app.use(cors({
-  origin: process.env.CORS_ORIGIN || '*',  
+  origin: allowedOrigins,
   methods: ['GET','POST','OPTIONS'],
 }));
 


### PR DESCRIPTION
## Summary
- make the API servers read `CORS_ORIGINS` env var
- default to production domain when the variable is missing
- document the new variable in README

## Testing
- `python -m py_compile app/main.py backend/app/main.py`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685b6d2a0c588322a6fcbee5a1c6c0e3