### PR TITLE
Fix Tailwind config export

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,6 @@
-module.exports = {
+export default {
   content: ["./frontend/src/**/*.{js,jsx,ts,tsx}"],
+  darkMode: 'media', // respect OS setting; or 'class' to toggle manually
   theme: {
     extend: {
       colors: {
@@ -12,14 +13,4 @@ module.exports = {
     },
   },
   plugins: [],
-}
-export default {
-  // or module.exports = { … } if you’re not using ESM
-  darkMode: 'media', // respect OS setting; or 'class' to toggle manually
-  theme: {
-    extend: {
-      // …your custom colors, offwhite, etc…
-    }
-  },
-  plugins: []
-}
+};


### PR DESCRIPTION
## Summary
- use a single ESM `export default` block in `tailwind.config.js`

## Testing
- `npx tailwindcss -i ./frontend/src/index.css -o /tmp/output.css --config tailwind.config.js` *(fails: 403 Forbidden due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_685b6180f8a883228ce5cf6107ae6cb5