### PR TITLE
Fix floor-traffic prefix and tests

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -39,6 +39,7 @@ app.include_router(leads_router,         prefix="/api/leads",         tags=["lea
 app.include_router(users_router,         prefix="/api/users",         tags=["users"])
 app.include_router(                      # floor-traffic now at /api/floor-traffic
     floor_traffic_router,
+    prefix="/api/floor-traffic",
     tags=["floor-traffic"],
 )
 app.include_router(accounts_router,      prefix="/api/accounts",      tags=["accounts"])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,20 +19,28 @@ if 'supabase' not in sys.modules:
     sys.modules['supabase'] = supabase_module
 
 # Provide stub httpx module if missing
+# Use the real 'httpx' library if available; otherwise fall back to the stub.
 if 'httpx' not in sys.modules:
-    import importlib
-    httpx_stub = importlib.import_module('tests.httpx_stub')
-    sys.modules['httpx'] = httpx_stub
-    sys.modules['httpx._client'] = httpx_stub._client
-    sys.modules['httpx._types'] = httpx_stub._types
+    try:
+        import httpx  # noqa: F401
+    except Exception:  # pragma: no cover - fallback only when httpx missing
+        import importlib
+        httpx_stub = importlib.import_module('tests.httpx_stub')
+        sys.modules['httpx'] = httpx_stub
+        sys.modules['httpx._client'] = httpx_stub._client
+        sys.modules['httpx._types'] = httpx_stub._types
 
 # Provide dummy email_validator module if missing
+# Use real 'email_validator' if available, otherwise minimal stub.
 if 'email_validator' not in sys.modules:
-    email_validator = types.ModuleType('email_validator')
-    class EmailNotValidError(ValueError):
-        pass
-    def validate_email(email, check_deliverability=True):
-        return ({'email': email}, email)
-    email_validator.EmailNotValidError = EmailNotValidError
-    email_validator.validate_email = validate_email
-    sys.modules['email_validator'] = email_validator
+    try:
+        import email_validator  # noqa: F401
+    except Exception:  # pragma: no cover
+        email_validator = types.ModuleType('email_validator')
+        class EmailNotValidError(ValueError):
+            pass
+        def validate_email(email, check_deliverability=True):
+            return ({'email': email}, email)
+        email_validator.EmailNotValidError = EmailNotValidError
+        email_validator.validate_email = validate_email
+        sys.modules['email_validator'] = email_validator

--- a/tests/httpx_stub.py
+++ b/tests/httpx_stub.py
@@ -60,9 +60,12 @@ class Client:
         self.follow_redirects = follow_redirects
         self.cookies = cookies
         self.app = app
+
+    def _merge_url(self, url: str) -> URL:
+        return self.base_url.join(url)
     def request(self, method, url, **kwargs):
-        joined = self.base_url.join(str(url))
-        full_url = str(joined)
+        merged = self._merge_url(str(url))
+        full_url = str(merged)
         req = Request(method, full_url, headers=kwargs.get("headers"), data=kwargs.get("content"))
         # Debug print
         # print('Request built', full_url, req.url.netloc)

--- a/tests/test_floor_traffic.py
+++ b/tests/test_floor_traffic.py
@@ -24,7 +24,7 @@ def test_get_today_floor_traffic():
     mock_supabase.table.return_value = mock_table
 
     with patch("app.routers.floor_traffic.supabase", mock_supabase):
-        response = client.get("/today")
+        response = client.get("/api/floor-traffic/today")
 
     assert response.status_code == 200
     assert response.json() == sample


### PR DESCRIPTION
## Summary
- mount the Python floor-traffic router under `/api/floor-traffic`
- update the floor traffic tests
- use real `httpx` and `email_validator` if available
- add `_merge_url` helper to `httpx_stub`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b72b40bf08322af2884721ffe1eda