### PR TITLE
Fix floor-traffic POST path

### DIFF
--- a/frontend/src/components/CreateFloorTrafficForm.jsx
+++ b/frontend/src/components/CreateFloorTrafficForm.jsx
@@ -36,7 +36,9 @@ export default function CreateFloorTrafficForm() {
     e.preventDefault();
     setError("");
     try {
-      const res = await fetch(`${API_BASE}/floor-traffic`, {
+      // The FastAPI backend expects a trailing slash while Express
+      // tolerates it, so include the slash to work with both.
+      const res = await fetch(`${API_BASE}/floor-traffic/`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(form),


### PR DESCRIPTION
## Summary
- add a trailing slash when posting floor‑traffic logs so the FastAPI router accepts the request

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b786304688322a1732127af75e273