### PR TITLE
Fix floor traffic endpoint and testing

### DIFF
--- a/app/routers/floor_traffic.py
+++ b/app/routers/floor_traffic.py
@@ -7,6 +7,7 @@ from app.models import FloorTrafficCustomer, FloorTrafficCustomerCreate
 router = APIRouter()
 
 @router.get(
+    "/today",
     response_model=list[FloorTrafficCustomer],
     summary="Get today's floor-traffic entries",
 )


### PR DESCRIPTION
## Summary
- fix path for `/api/floor-traffic/today`
- ensure tests work even if `httpx` doesn't support `app` parameter

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685dda95c50c8322b0c084543012f2b1