### PR TITLE
Fix floor traffic POST endpoint URL

### DIFF
--- a/frontend/src/components/CreateFloorTrafficForm.jsx
+++ b/frontend/src/components/CreateFloorTrafficForm.jsx
@@ -38,7 +38,7 @@ export default function CreateFloorTrafficForm() {
     try {
       // The FastAPI backend expects a trailing slash while Express
       // tolerates it, so include the slash to work with both.
-      const res = await fetch(`/floor-traffic/new`, {
+      const res = await fetch(`${API_BASE}/floor-traffic/`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(form),


### PR DESCRIPTION
## Summary
- submit new floor traffic entries to the backend API base

## Testing
- `python3 -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ddc31e4a8832281daef651647197d