### PR TITLE
Improve CORS origin handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,12 @@ npm run dev
 
 ## Environment Variables
 
-The FastAPI services expect `SUPABASE_URL` and `SUPABASE_KEY` to be
-
+The FastAPI services expect `SUPABASE_URL` and `SUPABASE_KEY` to be set. `CORS_ORIGINS` controls the allowed origins for both servers.
 
 ```env
 SUPABASE_URL=<your-supabase-url>
 SUPABASE_KEY=<your-supabase-key>
 CORS_ORIGINS=https://aiventa-crm.vercel.app,https://aiventa-g3al310q6-brian-dubles-projects.vercel.app
 ```
+
+Be sure to omit any trailing slashes from the origins.

--- a/app/main.py
+++ b/app/main.py
@@ -16,7 +16,11 @@ app = FastAPI(title="aiVenta CRM API")
 
 # 1️⃣ CORS: allow origins from env or default to production domain
 origins_env = os.environ.get("CORS_ORIGINS", "https://aiventa-crm.vercel.app")
-allowed_origins = [o.strip() for o in origins_env.split(",") if o.strip()]
+allowed_origins = [
+    o.strip().rstrip("/")
+    for o in origins_env.split(",")
+    if o.strip()
+]
 app.add_middleware(
     CORSMiddleware,
     allow_origins=allowed_origins,

--- a/index.js
+++ b/index.js
@@ -7,7 +7,10 @@ const app = express();
 
 // Allow requests from configured origins
 const originsEnv = process.env.CORS_ORIGINS || 'https://aiventa-crm.vercel.app';
-const allowedOrigins = originsEnv.split(',').map(o => o.trim()).filter(Boolean);
+const allowedOrigins = originsEnv
+  .split(',')
+  .map(o => o.trim().replace(/\/+$/, ''))
+  .filter(Boolean);
 app.use(cors({
   origin: allowedOrigins,
   methods: ['GET','POST','OPTIONS'],


### PR DESCRIPTION
## Summary
- normalize origins in Express API
- normalize origins in FastAPI
- clean up README and document trailing slash note

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685dddec099c8322983875ac9df874b9