### PR TITLE
Fix leads endpoint no-slash

### DIFF
--- a/app/routers/leads.py
+++ b/app/routers/leads.py
@@ -16,7 +16,9 @@ class Lead(BaseModel):
     email: EmailStr
 
 @router.get("/", response_model=List[Lead])
+@router.get("", response_model=List[Lead], include_in_schema=False)
 def list_leads():
+    """Return all leads."""
     res = supabase.table("leads").select("*").execute()
     return res.data
 


### PR DESCRIPTION
## Summary
- handle `/api/leads` URL without trailing slash

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ecb4982a88322979314223c1b1f0b