### PR TITLE
Fix logo import for Home route

### DIFF
--- a/frontend/src/routes/Home.jsx
+++ b/frontend/src/routes/Home.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import logo from '../assets/logo.png';
 
 export default function Home() {
   return (


### PR DESCRIPTION
## Summary
- import logo in `Home.jsx` route

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685f33c5bd188322989d8af01e0bb76a