### PR TITLE
Enhance home page link with sheen hover effect

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -79,3 +79,28 @@ button:focus-visible {
   background-size: 200% 200%;
   animation: gradient-move 8s ease infinite;
 }
+
+/* sheen effect for prominent links */
+.sheen-link {
+  position: relative;
+  overflow: hidden;
+}
+
+.sheen-link::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: -150%;
+  width: 50%;
+  height: 100%;
+  background: linear-gradient(120deg, rgba(255,255,255,0.0) 0%, rgba(255,255,255,0.5) 50%, rgba(255,255,255,0.0) 100%);
+  transform: skewX(-25deg);
+}
+
+.sheen-link:hover::after {
+  animation: sheen-move 0.7s forwards;
+}
+
+@keyframes sheen-move {
+  to { left: 200%; }
+}

--- a/frontend/src/routes/Home.jsx
+++ b/frontend/src/routes/Home.jsx
@@ -14,7 +14,7 @@ export default function Home() {
         </p>
         <a
           href="/leads"
-          className="inline-block px-8 py-4 text-lg font-semibold text-darkblue bg-neongreen rounded-md shadow-xl hover:bg-offwhite hover:text-darkblue transition-colors"
+          className="sheen-link inline-block px-8 py-4 text-lg font-semibold text-darkblue bg-neongreen rounded-md shadow-xl hover:bg-offwhite hover:text-darkblue transition-colors"
         >
           Get Started
         </a>


### PR DESCRIPTION
## Summary
- add new `.sheen-link` class for an animated sheen effect
- apply the new class to the "Get Started" link on the home page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f5748dc948322ba3858808591407b