### PR TITLE
Fix CORS for vercel previews

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -24,6 +24,7 @@ allowed_origins = [
 app.add_middleware(
     CORSMiddleware,
     allow_origins=allowed_origins,
+    allow_origin_regex=r"https://.*\.vercel\.app$",
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/index.js
+++ b/index.js
@@ -11,8 +11,24 @@ const allowedOrigins = originsEnv
   .split(',')
   .map(o => o.trim().replace(/\/+$/, ''))
   .filter(Boolean);
+
+// Support wildcard subdomains for Vercel preview URLs
+function isOriginAllowed(origin) {
+  if (!origin) return true; // allow same-origin or non-browser requests
+  if (allowedOrigins.includes(origin)) return true;
+  return allowedOrigins.some(o =>
+    o.endsWith('.vercel.app') && origin.endsWith('.vercel.app')
+  );
+}
+
 app.use(cors({
-  origin: allowedOrigins,
+  origin: (origin, callback) => {
+    if (isOriginAllowed(origin)) {
+      callback(null, true);
+    } else {
+      callback(new Error('Not allowed by CORS'));
+    }
+  },
   methods: ['GET','POST','OPTIONS'],
 }));
 


### PR DESCRIPTION
## Summary
- relax CORS checks to allow `*.vercel.app` preview URLs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685f5cb82594832284f362535a16781f