### PR TITLE
Fix validation error message handling

### DIFF
--- a/frontend/src/components/CreateFloorTrafficForm.jsx
+++ b/frontend/src/components/CreateFloorTrafficForm.jsx
@@ -58,7 +58,10 @@ export default function CreateFloorTrafficForm() {
       }
       if (res.status === 422) {
         const payload = await res.json();
-        throw new Error(payload.message || "Validation failed");
+        const msg =
+          payload.message ||
+          (typeof payload.detail === "string" ? payload.detail : undefined);
+        throw new Error(msg || "Validation failed");
       }
       if (!res.ok) {
         throw new Error("Failed to save, please try again.");


### PR DESCRIPTION
## Summary
- surface error details in CreateFloorTrafficForm when API returns a `detail` field

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f61e56bd083228c61958283a6db71