### PR TITLE
Fix floor log time handling

### DIFF
--- a/frontend/src/components/CreateFloorTrafficForm.jsx
+++ b/frontend/src/components/CreateFloorTrafficForm.jsx
@@ -38,10 +38,23 @@ export default function CreateFloorTrafficForm() {
     try {
       // The FastAPI backend expects a trailing slash while Express
       // tolerates it, so include the slash to work with both.
+      let visitTime = form.timeIn;
+      let timeOut = form.timeOut;
+      const today = new Date().toISOString().slice(0, 10);
+      // If the value is just HH:MM, combine with today's date
+      if (visitTime && !visitTime.includes('T')) {
+        visitTime = `${today}T${visitTime}`;
+      }
+      if (timeOut && !timeOut.includes('T')) {
+        timeOut = `${today}T${timeOut}`;
+      }
+
       const payload = {
         ...form,
+        timeIn: visitTime,
+        timeOut,
         // Include aliases expected by the FastAPI backend
-        visit_time: form.timeIn,
+        visit_time: visitTime,
         customer_name: form.customerName,
       };
       const res = await fetch(`${API_BASE}/floor-traffic/`, {


### PR DESCRIPTION
## Summary
- ensure both check-in and check-out times are converted to ISO strings before submitting floor log

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685f6334144083229ad46faf5a2b5c4b