### PR TITLE
Create horizontal logo component

### DIFF
--- a/frontend/src/components/Home.jsx
+++ b/frontend/src/components/Home.jsx
@@ -1,6 +1,7 @@
 // frontend/src/components/Home.jsx
 import React from 'react';
 import { Link } from 'react-router-dom';
+import Logo from './Logo';
 
 export default function Home() {
   return (
@@ -9,12 +10,8 @@ export default function Home() {
       <div className="absolute inset-0 bg-gradient-to-tr from-purple-700 via-blue-500 to-green-400 opacity-60" />
       {/* content */}
       <div className="relative z-10 space-y-6">
-        {/* point directly to /logo.png in public/ */}
-        <img
-          src="/logo.png"
-          alt="aiVenta Logo"
-          className="mx-auto h-24 w-auto drop-shadow-xl"
-        />
+        {/* display logo with brand text */}
+        <Logo className="mx-auto" />
 
         <p className="text-xl sm:text-3xl font-medium max-w-2xl mx-auto">
           Manage leads, users and floor traffic with next-gen efficiency.

--- a/frontend/src/components/Logo.jsx
+++ b/frontend/src/components/Logo.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default function Logo({ className = '' }) {
+  return (
+    <span className={`inline-flex items-center space-x-2 ${className}`.trim()}>
+      <img src="/logo.png" alt="aiVenta icon" className="h-8 w-8" />
+      <span className="text-2xl font-semibold">aiVenta</span>
+    </span>
+  );
+}

--- a/frontend/src/routes/Home.jsx
+++ b/frontend/src/routes/Home.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import Logo from '../components/Logo';
 
 export default function Home() {
   return (
@@ -6,7 +7,7 @@ export default function Home() {
       <div className="absolute inset-0 bg-gradient-to-tr from-purple-700 via-electricblue to-neongreen opacity-60 animate-gradient" />
       <div className="relative z-10">
         <h1 className="text-5xl sm:text-7xl font-extrabold tracking-tight mb-6 drop-shadow-2xl">
-          <img src="/logo.png" alt="aiVenta Logo" />
+          <Logo className="mx-auto" />
         </h1>
         <p className="text-xl sm:text-3xl mb-8 max-w-3xl font-medium">
           Manage leads, users and floor traffic with next‑gen efficiency.


### PR DESCRIPTION
## Summary
- revert binary logo change
- add a new `Logo` component that displays the logo icon beside the brand text
- use the `Logo` component on both `Home` pages

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68649c47c028832296502fe209dd9515