### PR TITLE
Fix users page fetching

### DIFF
--- a/frontend/src/routes/Users.jsx
+++ b/frontend/src/routes/Users.jsx
@@ -3,12 +3,22 @@ import React, { useEffect, useState } from 'react'
 
 export default function Users() {
   const [users, setUsers] = useState([])
+  const [error, setError] = useState('')
+
+  // Use configured API base URL or default to the proxy path
+  const API_BASE = import.meta.env.VITE_API_BASE_URL || '/api'
 
   useEffect(() => {
-    fetch(import.meta.env.VITE_API_BASE_URL + '/users')
-      .then(res => res.json())
+    fetch(`${API_BASE}/users`)
+      .then(res => {
+        if (!res.ok) throw new Error('Failed to load users')
+        return res.json()
+      })
       .then(setUsers)
-      .catch(console.error)
+      .catch(err => {
+        console.error(err)
+        setError('Unable to fetch users')
+      })
   }, [])
 
   return (
@@ -19,6 +29,7 @@ export default function Users() {
           <li key={u.id}>{u.name}</li>
         ))}
       </ul>
+      {error && <p style={{ color: 'red' }}>{error}</p>}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- add fallback `/api` API base for Users route
- display error message if user list fetch fails

## Testing
- `npm test` *(fails: Missing script)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68657703ba708322bc2464d96632a370