### PR TITLE
Fix home page branding

### DIFF
--- a/frontend/src/routes/Home.jsx
+++ b/frontend/src/routes/Home.jsx
@@ -7,11 +7,8 @@ export default function Home() {
       <div className="absolute inset-0 bg-gradient-to-tr from-purple-700 via-electricblue to-neongreen opacity-60 animate-gradient" />
       <div className="relative z-10">
         <h1 className="text-5xl sm:text-7xl font-extrabold tracking-tight mb-6 drop-shadow-2xl">
-
-          aiVenta CRM
-
+          <span className="sr-only">aiVenta CRM</span>
           <Logo className="mx-auto" />
-
         </h1>
         <p className="text-xl sm:text-3xl mb-8 max-w-3xl font-medium">
           Manage leads, users and floor traffic with next‑gen efficiency.


### PR DESCRIPTION
## Summary
- remove redundant brand name when the logo is displayed on the home page

## Testing
- `pytest -q`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6865ba722e688322a5f1248b6f524793