### PR TITLE
Fix Supabase insert error in floor traffic router

### DIFF
--- a/app/routers/floor_traffic.py
+++ b/app/routers/floor_traffic.py
@@ -64,10 +64,10 @@ async def create_floor_traffic(entry: FloorTrafficCustomerCreate):
             supabase
             .table("floor_traffic_customers")
             .insert(payload)
-            .single()
             .execute()
         )
     except APIError as e:
         raise HTTPException(status_code=400, detail=e.message)
-    return res.data
+    # `.insert()` returns a list of inserted rows
+    return res.data[0] if isinstance(res.data, list) and res.data else res.data
 

--- a/tests/test_floor_traffic.py
+++ b/tests/test_floor_traffic.py
@@ -47,9 +47,9 @@ def test_create_floor_traffic():
         "created_at": "2024-01-01T10:00:00",
     }
 
-    exec_result = MagicMock(data=sample, error=None)
+    exec_result = MagicMock(data=[sample], error=None)
     mock_table = MagicMock()
-    mock_table.insert.return_value.single.return_value.execute.return_value = exec_result
+    mock_table.insert.return_value.execute.return_value = exec_result
     mock_supabase = MagicMock()
     mock_supabase.table.return_value = mock_table
 


### PR DESCRIPTION
## Summary
- remove unsupported `.single()` call when inserting a floor traffic entry
- handle returned list from Supabase insert
- adjust floor traffic unit test to match

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865c9a035c08322ba8e45092268bace