### PR TITLE
Add inventory API

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -11,6 +11,7 @@ from app.routers.accounts        import router as accounts_router
 from app.routers.contacts        import router as contacts_router
 from app.routers.opportunities   import router as opportunities_router
 from app.routers.activities      import router as activities_router
+from app.routers.inventory       import router as inventory_router
 
 app = FastAPI(title="aiVenta CRM API")
 
@@ -51,6 +52,7 @@ app.include_router(accounts_router,      prefix="/api/accounts",      tags=["acc
 app.include_router(contacts_router,      prefix="/api/contacts",      tags=["contacts"])
 app.include_router(opportunities_router, prefix="/api/opportunities", tags=["opportunities"])
 app.include_router(activities_router,    prefix="/api/activities",    tags=["activities"])
+app.include_router(inventory_router,     prefix="/api/inventory",    tags=["inventory"])
 
 # 4️⃣ Serve your React app for all other GETs
 app.mount(

--- a/app/models.py
+++ b/app/models.py
@@ -145,3 +145,60 @@ class FloorTrafficCustomerUpdate(BaseModel):
 
 # … your existing Contact, Opportunity, etc. …
 
+
+# ── Inventory ─────────────────────────────────────────────────────────────────
+
+class InventoryItem(BaseModel):
+    id: int
+    stockNumber: Optional[str] = None
+    vin: Optional[str] = None
+    year: Optional[int] = None
+    make: Optional[str] = None
+    model: Optional[str] = None
+    trim: Optional[str] = None
+    price: Optional[float] = None
+    mileage: Optional[int] = None
+    color: Optional[str] = None
+    condition: Optional[str] = None
+    fuelType: Optional[str] = None
+    drivetrain: Optional[str] = None
+    active: Optional[bool] = True
+    videoUrls: Optional[list[str]] = None
+    historyReport: Optional[str] = None
+
+
+class InventoryItemCreate(BaseModel):
+    stockNumber: Optional[str] = None
+    vin: Optional[str] = None
+    year: Optional[int] = None
+    make: Optional[str] = None
+    model: Optional[str] = None
+    trim: Optional[str] = None
+    price: Optional[float] = None
+    mileage: Optional[int] = None
+    color: Optional[str] = None
+    condition: Optional[str] = None
+    fuelType: Optional[str] = None
+    drivetrain: Optional[str] = None
+    active: Optional[bool] = True
+    videoUrls: Optional[list[str]] = None
+    historyReport: Optional[str] = None
+
+
+class InventoryItemUpdate(BaseModel):
+    stockNumber: Optional[str] = None
+    vin: Optional[str] = None
+    year: Optional[int] = None
+    make: Optional[str] = None
+    model: Optional[str] = None
+    trim: Optional[str] = None
+    price: Optional[float] = None
+    mileage: Optional[int] = None
+    color: Optional[str] = None
+    condition: Optional[str] = None
+    fuelType: Optional[str] = None
+    drivetrain: Optional[str] = None
+    active: Optional[bool] = None
+    videoUrls: Optional[list[str]] = None
+    historyReport: Optional[str] = None
+

--- a/app/routers/inventory.py
+++ b/app/routers/inventory.py
@@ -1,0 +1,61 @@
+from fastapi import APIRouter, HTTPException, status
+from postgrest.exceptions import APIError
+from app.db import supabase
+from app.models import InventoryItem, InventoryItemCreate, InventoryItemUpdate
+
+router = APIRouter()
+
+@router.get("/", response_model=list[InventoryItem])
+def list_inventory():
+    res = supabase.table("inventory").select("*").execute()
+    return res.data
+
+@router.get("/{item_id}", response_model=InventoryItem)
+def get_inventory_item(item_id: int):
+    res = (
+        supabase.table("inventory")
+        .select("*")
+        .eq("id", item_id)
+        .maybe_single()
+        .execute()
+    )
+    if not res.data:
+        raise HTTPException(status_code=404, detail="Item not found")
+    return res.data
+
+@router.post("/", response_model=InventoryItem, status_code=status.HTTP_201_CREATED)
+def create_inventory_item(item: InventoryItemCreate):
+    payload = item.dict(exclude_unset=True)
+    try:
+        res = supabase.table("inventory").insert(payload).execute()
+    except APIError as e:
+        raise HTTPException(status_code=400, detail=e.message)
+    return res.data[0]
+
+@router.put("/{item_id}", response_model=InventoryItem)
+def update_inventory_item(item_id: int, item: InventoryItemUpdate):
+    payload = {k: v for k, v in item.dict(exclude_unset=True).items() if v is not None}
+    if not payload:
+        raise HTTPException(status_code=400, detail="No fields to update")
+    try:
+        res = (
+            supabase.table("inventory")
+            .update(payload)
+            .eq("id", item_id)
+            .execute()
+        )
+    except APIError as e:
+        raise HTTPException(status_code=400, detail=e.message)
+    if not res.data:
+        raise HTTPException(status_code=404, detail="Item not found")
+    return res.data[0]
+
+@router.delete("/{item_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_inventory_item(item_id: int):
+    try:
+        res = supabase.table("inventory").delete().eq("id", item_id).execute()
+    except APIError as e:
+        raise HTTPException(status_code=400, detail=e.message)
+    if not res.data:
+        raise HTTPException(status_code=404, detail="Item not found")
+    return

--- a/tests/test_inventory.py
+++ b/tests/test_inventory.py
@@ -1,0 +1,44 @@
+from fastapi.testclient import TestClient
+from unittest.mock import MagicMock, patch
+from app.main import app
+import json
+
+client = TestClient(app)
+
+
+def test_list_inventory():
+    sample = [{"id": 1, "stockNumber": "A123"}]
+    exec_result = MagicMock(data=sample, error=None)
+    mock_table = MagicMock()
+    mock_table.select.return_value.execute.return_value = exec_result
+    mock_supabase = MagicMock()
+    mock_supabase.table.return_value = mock_table
+
+    with patch("app.routers.inventory.supabase", mock_supabase):
+        response = client.get("/api/inventory/")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert isinstance(data, list)
+    assert data[0]["stockNumber"] == "A123"
+
+
+def test_create_inventory():
+    sample = {"id": 1, "stockNumber": "A123"}
+    exec_result = MagicMock(data=[sample], error=None)
+    mock_table = MagicMock()
+    mock_table.insert.return_value.execute.return_value = exec_result
+    mock_supabase = MagicMock()
+    mock_supabase.table.return_value = mock_table
+
+    payload = {"stockNumber": "A123"}
+    with patch("app.routers.inventory.supabase", mock_supabase):
+        response = client.post(
+            "/api/inventory/",
+            content=json.dumps(payload),
+            headers={"Content-Type": "application/json"},
+        )
+
+    assert response.status_code == 201
+    data = response.json()
+    assert data["stockNumber"] == "A123"


### PR DESCRIPTION
## Summary
- implement `inventory` models
- add `inventory` router with CRUD routes
- expose new router via FastAPI app
- test new endpoints

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865d19019ac832290a9458af11e7163