### PR TITLE
Mount inventory router

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -4,6 +4,7 @@ import cors from 'cors';
 import floorTrafficRouter from '../routes/floorTraffic.js';
 import leadsRouter from '../routes/leads.js';
 import usersRouter from '../routes/users.js';
+import inventoryRouter from '../backend/routes/inventory.js';
 import { startAdfIngestJob } from './jobs/adfIngestJob.js';
 
 const app = express();
@@ -58,6 +59,7 @@ app.get('/health', (req, res) => {
 app.use('/api', floorTrafficRouter);
 app.use('/api', leadsRouter);
 app.use('/api', usersRouter);
+app.use('/api/inventory', inventoryRouter);
 
 // Fallback for unknown routes
 app.use((req, res) => {


### PR DESCRIPTION
## Summary
- import the inventory router into the Express server
- mount `/api/inventory` alongside existing API routes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6866b01dfa888322b18cb41a9418fb3d