### PR TITLE
Add inventory filtering

### DIFF
--- a/tests/test_inventory.py
+++ b/tests/test_inventory.py
@@ -42,3 +42,27 @@ def test_create_inventory():
     assert response.status_code == 201
     data = response.json()
     assert data["stockNumber"] == "A123"
+
+
+def test_filter_inventory_query_params():
+    sample = [{"id": 2, "make": "Ford"}]
+    exec_result = MagicMock(data=sample, error=None)
+
+    mock_query = MagicMock()
+    mock_query.ilike.return_value = mock_query
+    mock_query.gte.return_value = mock_query
+    mock_query.execute.return_value = exec_result
+
+    mock_table = MagicMock()
+    mock_table.select.return_value = mock_query
+    mock_supabase = MagicMock()
+    mock_supabase.table.return_value = mock_table
+
+    with patch("app.routers.inventory.supabase", mock_supabase):
+        response = client.get("/api/inventory/?make=Ford&year_min=2020")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data[0]["make"] == "Ford"
+    mock_query.ilike.assert_called_with("make", "%Ford%")
+    mock_query.gte.assert_called_with("year", 2020)


### PR DESCRIPTION
## Summary
- support basic query parameter filtering in the FastAPI inventory router
- add tests covering the new query params

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68674ff5d8908322900ba18b1e8fa3d0