### PR TITLE
Relax CORS settings

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -15,18 +15,21 @@ from app.routers import inventory  # inventory router mounted under /api/invento
 
 app = FastAPI(title="aiVenta CRM API")
 
-# 1️⃣ CORS: allow origins from env or default to production domain
-origins_env = os.environ.get("CORS_ORIGINS", "https://aiventa-crm.vercel.app, http://localhost:3000")
-allowed_origins = [
-    o.strip().rstrip("/")
-    for o in origins_env.split(",")
-    if o.strip()
-]
+# 1️⃣ CORS: allow origins from env or fall back to permissive defaults
+origins_env = os.environ.get("CORS_ORIGINS", "")
+if origins_env:
+    allowed_origins = [o.strip().rstrip("/") for o in origins_env.split(",") if o.strip()]
+else:
+    allowed_origins = ["*"]  # open during local/dev if not configured
+
+allow_credentials = False if "*" in allowed_origins else True
+allow_regex = None if "*" in allowed_origins else r"https://.*\.vercel\.app$"
+
 app.add_middleware(
     CORSMiddleware,
     allow_origins=allowed_origins,
-    allow_origin_regex=r"https://.*\.vercel\.app$",
-    allow_credentials=True,
+    allow_origin_regex=allow_regex,
+    allow_credentials=allow_credentials,
     allow_methods=["*"],
     allow_headers=["*"],
 )

--- a/backend/app.js
+++ b/backend/app.js
@@ -4,7 +4,27 @@ const app     = express();
 const cors    = require('cors');
 
 app.use(express.json());
-app.use(cors());  // configure with your CORS_ORIGINS
+
+// Configure CORS using the same env variable as the FastAPI app
+const originsEnv = process.env.CORS_ORIGINS || 'https://aiventa-crm.vercel.app';
+const allowedOrigins = originsEnv
+  .split(',')
+  .map(o => o.trim().replace(/\/+$/, ''))
+  .filter(Boolean);
+app.use(
+  cors({
+    origin: (origin, cb) => {
+      if (!origin || allowedOrigins.includes(origin) ||
+          (origin.endsWith('.vercel.app') && allowedOrigins.some(o => o.endsWith('.vercel.app')))) {
+        cb(null, true);
+      } else {
+        cb(new Error('Not allowed by CORS'));
+      }
+    },
+    methods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
+    allowedHeaders: ['Content-Type', 'Authorization'],
+  })
+);  // configure with your CORS_ORIGINS
 
 // Mount your new inventory router:
 const inventoryRouter = require('./routes/inventory');

--- a/env.example
+++ b/env.example
@@ -1,3 +1,4 @@
 SUPABASE_URL=<your-supabase-url>
 SUPABASE_KEY=<your-supabase-key>
-CORS_ORIGINS=<allowed-origins-comma-separated>
+# Comma separated list of origins allowed to access the APIs. Leave empty for '*' in dev
+CORS_ORIGINS=

--- a/server/index.js
+++ b/server/index.js
@@ -38,8 +38,6 @@ const corsOptions = {
     }
   },
 
-  methods: ['GET', 'POST', 'PUT', 'OPTIONS'],
-
   methods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
 
   allowedHeaders: ['Content-Type', 'Authorization'],

--- a/tests/test_cors.py
+++ b/tests/test_cors.py
@@ -10,4 +10,22 @@ def test_cors_get():
         headers={"Origin": "https://aiventa-crm.vercel.app"},
     )
     assert resp.status_code in (200, 404, 500)
-    assert resp.headers.get("access-control-allow-origin") == "https://aiventa-crm.vercel.app"
+    assert resp.headers.get("access-control-allow-origin") in ("https://aiventa-crm.vercel.app", "*")
+
+
+def test_cors_inventory():
+    from unittest.mock import MagicMock, patch
+
+    mock_table = MagicMock()
+    mock_table.select.return_value.execute.return_value = MagicMock(data=[], error=None)
+    mock_supabase = MagicMock()
+    mock_supabase.table.return_value = mock_table
+
+    with patch("app.routers.inventory.supabase", mock_supabase):
+        resp = client.get(
+            "/api/inventory/",
+            headers={"Origin": "https://aiventa-crm.vercel.app"},
+        )
+
+    assert resp.status_code in (200, 404, 500)
+    assert resp.headers.get("access-control-allow-origin") in ("https://aiventa-crm.vercel.app", "*")

--- a/tests/test_inventory.py
+++ b/tests/test_inventory.py
@@ -42,3 +42,27 @@ def test_create_inventory():
     assert response.status_code == 201
     data = response.json()
     assert data["stockNumber"] == "A123"
+
+
+def test_filter_inventory_query_params():
+    sample = [{"id": 2, "make": "Ford"}]
+    exec_result = MagicMock(data=sample, error=None)
+
+    mock_query = MagicMock()
+    mock_query.ilike.return_value = mock_query
+    mock_query.gte.return_value = mock_query
+    mock_query.execute.return_value = exec_result
+
+    mock_table = MagicMock()
+    mock_table.select.return_value = mock_query
+    mock_supabase = MagicMock()
+    mock_supabase.table.return_value = mock_table
+
+    with patch("app.routers.inventory.supabase", mock_supabase):
+        response = client.get("/api/inventory/?make=Ford&year_min=2020")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data[0]["make"] == "Ford"
+    mock_query.ilike.assert_called_with("make", "%Ford%")
+    mock_query.gte.assert_called_with("year", 2020)


### PR DESCRIPTION
## Summary
- loosen CORS defaults to allow '*' when no CORS_ORIGINS provided
- unify Node/Express CORS logic with FastAPI
- document env var in env.example
- test CORS on inventory endpoint

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68674ff5d8908322900ba18b1e8fa3d0