### PR TITLE
Add floor traffic dashboard page

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
+        "@supabase/supabase-js": "^2.50.3",
         "framer-motion": "^12.23.0",
         "lucide-react": "^0.525.0",
         "react": "^19.1.0",
@@ -1391,6 +1392,81 @@
         "win32"
       ]
     },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.70.0",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.70.0.tgz",
+      "integrity": "sha512-BaAK/tOAZFJtzF1sE3gJ2FwTjLf4ky3PSvcvLGEgEmO4BSBkwWKu8l67rLLIBZPDnCyV7Owk2uPyKHa0kj5QGg==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.4.5.tgz",
+      "integrity": "sha512-v5GSqb9zbosquTo6gBwIiq7W9eQ7rE5QazsK/ezNiQXdCbY+bH8D9qEaBIkhVvX4ZRW5rP03gEfw5yw9tiq4EQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/node-fetch": {
+      "version": "2.6.15",
+      "resolved": "https://registry.npmjs.org/@supabase/node-fetch/-/node-fetch-2.6.15.tgz",
+      "integrity": "sha512-1ibVeYUacxWYi9i0cf5efil6adJ9WRyZBLivgjs+AUpewx1F3xPi7gLgaASI2SmIQxPoCEjAsLAzKPgMJVgOUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      }
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "1.19.4",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-1.19.4.tgz",
+      "integrity": "sha512-O4soKqKtZIW3olqmbXXbKugUtByD2jPa8kL2m2c1oozAO11uCcGrRhkZL0kVxjBLrXHE0mdSkFsMj7jDSfyNpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.11.15",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.11.15.tgz",
+      "integrity": "sha512-HQKRnwAqdVqJW/P9TjKVK+/ETpW4yQ8tyDPPtRMKOH4Uh3vQD74vmj353CYs8+YwVBKubeUOOEpI9CT8mT4obw==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.13",
+        "@types/phoenix": "^1.6.6",
+        "@types/ws": "^8.18.1",
+        "isows": "^1.0.7",
+        "ws": "^8.18.2"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.7.1.tgz",
+      "integrity": "sha512-asYHcyDR1fKqrMpytAS1zjyEfvxuOIp1CIXX7ji4lHHcJKqyk+sLl/Vxgm4sN6u8zvuUtae9e4kDxQP2qrwWBA==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.50.3",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.50.3.tgz",
+      "integrity": "sha512-Ld42AbfSXKnbCE2ObRvrGC5wj9OrfTOzswQZg0OcGQGx+QqcWYN/IqsLqrt4gCFrD57URbNRfGESSWzchzKAuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-js": "2.70.0",
+        "@supabase/functions-js": "2.4.5",
+        "@supabase/node-fetch": "2.6.15",
+        "@supabase/postgrest-js": "1.19.4",
+        "@supabase/realtime-js": "2.11.15",
+        "@supabase/storage-js": "2.7.1"
+      }
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1450,6 +1526,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/node": {
+      "version": "24.0.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.10.tgz",
+      "integrity": "sha512-ENHwaH+JIRTDIEEbDK6QSQntAYGtbvdDXnMXnZaZ6k13Du1dPMmprkEHIL7ok2Wl2aZevetwTAb5S+7yIF+enA==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.8.0"
+      }
+    },
+    "node_modules/@types/phoenix": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.6.6.tgz",
+      "integrity": "sha512-PIzZZlEppgrpoT2QgbnDU+MMzuR6BbCjllj0bM70lWoejMeNJAxCchxnv7J3XFkI8MpygtRpzXrIlmWUBclP5A==",
+      "license": "MIT"
+    },
     "node_modules/@types/react": {
       "version": "19.1.7",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.7.tgz",
@@ -1468,6 +1559,15 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.0.0"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@vitejs/plugin-react": {
@@ -2660,6 +2760,21 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/isows": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/isows/-/isows-1.0.7.tgz",
+      "integrity": "sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "ws": "*"
+      }
     },
     "node_modules/jackspeak": {
       "version": "3.4.3",
@@ -3919,6 +4034,12 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
     "node_modules/ts-interface-checker": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
@@ -3944,6 +4065,12 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
+      "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
+      "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
       "version": "1.1.3",
@@ -4068,6 +4195,22 @@
         }
       }
     },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -4187,6 +4330,27 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/yallist": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,7 +15,8 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-hot-toast": "^2.5.2",
-    "react-router-dom": "^7.6.2"
+    "react-router-dom": "^7.6.2",
+    "@supabase/supabase-js": "^2.50.3"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -8,7 +8,7 @@ import InventoryPage          from "./routes/InventoryPage";
 import { Toaster }            from 'react-hot-toast';
 import ActivityTimeline       from "./components/ActivityTimeline";
 import CreateLeadForm         from "./components/CreateLeadForm";
-import FloorLog               from "./routes/FloorLog";
+import FloorTrafficPage       from "./pages/FloorTrafficPage";
 import CreateFloorTrafficForm from "./components/CreateFloorTrafficForm";
 import Home                   from "./routes/Home";
 import Logo                   from "./components/Logo";
@@ -92,7 +92,7 @@ export default function App() {
           <Route path="/users" element={<UsersPage />} />
           <Route path="/inventory" element={<InventoryPage />} />
           <Route path="/activities" element={<ActivityTimeline />} />
-          <Route path="/floor-traffic" element={<FloorLog />} />
+          <Route path="/floor-traffic" element={<FloorTrafficPage />} />
           <Route path="/floor-traffic/new" element={<CreateFloorTrafficForm />} />
         </Routes>
       </div>

--- a/frontend/src/components/FloorTrafficTable.jsx
+++ b/frontend/src/components/FloorTrafficTable.jsx
@@ -1,0 +1,114 @@
+import React, { useState } from 'react';
+import { Phone, MessageCircle, Mail } from 'lucide-react';
+
+export default function FloorTrafficTable({ rows }) {
+  const [sortConfig, setSortConfig] = useState({ key: 'visit_time', direction: 'ascending' });
+  const [acknowledged, setAcknowledged] = useState(new Set());
+
+  const toggleSort = key => {
+    setSortConfig(prev => {
+      if (prev.key === key) {
+        const direction = prev.direction === 'ascending' ? 'descending' : 'ascending';
+        return { key, direction };
+      }
+      return { key, direction: 'ascending' };
+    });
+  };
+
+  const sorted = [...rows].sort((a, b) => {
+    const { key, direction } = sortConfig;
+    const valA = a[key];
+    const valB = b[key];
+    if (valA === null || valA === undefined) return 1;
+    if (valB === null || valB === undefined) return -1;
+    if (valA < valB) return direction === 'ascending' ? -1 : 1;
+    if (valA > valB) return direction === 'ascending' ? 1 : -1;
+    return 0;
+  });
+
+  const headers = [
+    { key: 'visit_time', label: 'Visit Time' },
+    { key: 'salesperson', label: 'Salesperson' },
+    { key: 'customer_name', label: 'Customer' },
+    { key: 'vehicle', label: 'Vehicle' },
+    { key: 'trade', label: 'Trade' },
+    { key: 'demo', label: 'Demo' },
+    { key: 'origin', label: 'Origin' }
+  ];
+
+  const handleRowClick = id => {
+    setAcknowledged(prev => new Set(prev).add(id));
+  };
+
+  const renderRow = row => {
+    const isUnresponded = !row.last_response_time && !acknowledged.has(row.id);
+    const rowClasses = `flex flex-col sm:table-row ${isUnresponded ? 'animate-pulse bg-red-50' : ''}`;
+    return (
+      <tr key={row.id} className={rowClasses} role="row" onClick={() => handleRowClick(row.id)}>
+        {headers.map(h => (
+          <td key={h.key} className="p-2" role="cell" data-label={h.label}>
+            {h.key === 'visit_time' ? new Date(row[h.key]).toLocaleTimeString() : String(row[h.key] ?? '')}
+          </td>
+        ))}
+        <td className="p-2 space-x-1" role="cell">
+          <button
+            aria-label={`Call ${row.customer_name}`}
+            className="rounded-full p-2 hover:bg-gray-100 transition"
+            onClick={e => {
+              e.stopPropagation();
+              window.location.href = `tel:${row.phone ?? ''}`;
+            }}
+          >
+            <Phone className="h-4 w-4" />
+          </button>
+          <button
+            aria-label={`Text ${row.customer_name}`}
+            className="rounded-full p-2 hover:bg-gray-100 transition"
+            onClick={e => {
+              e.stopPropagation();
+              window.location.href = `sms:${row.phone ?? ''}`;
+            }}
+          >
+            <MessageCircle className="h-4 w-4" />
+          </button>
+          <button
+            aria-label={`Email ${row.customer_name}`}
+            className="rounded-full p-2 hover:bg-gray-100 transition"
+            onClick={e => {
+              e.stopPropagation();
+              window.location.href = `mailto:${row.email ?? ''}`;
+            }}
+          >
+            <Mail className="h-4 w-4" />
+          </button>
+        </td>
+      </tr>
+    );
+  };
+
+  return (
+    <div className="overflow-x-auto w-full">
+      <table className="min-w-full" role="table">
+        <thead>
+          <tr role="row" className="bg-electricblue text-white">
+            {headers.map(h => (
+              <th
+                key={h.key}
+                role="columnheader"
+                aria-sort={sortConfig.key === h.key ? sortConfig.direction : 'none'}
+                className="p-2 text-left cursor-pointer select-none"
+                onClick={() => toggleSort(h.key)}
+              >
+                {h.label}
+              </th>
+            ))}
+            <th role="columnheader" className="p-2 text-left">Actions</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y" role="rowgroup">
+          {sorted.map(renderRow)}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/frontend/src/pages/FloorTrafficPage.jsx
+++ b/frontend/src/pages/FloorTrafficPage.jsx
@@ -1,0 +1,76 @@
+import React, { useEffect, useState } from 'react';
+import { createClient } from '@supabase/supabase-js';
+import FloorTrafficTable from '../components/FloorTrafficTable';
+
+export default function FloorTrafficPage() {
+  const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
+  const supabaseKey = import.meta.env.VITE_SUPABASE_KEY;
+  const supabase = createClient(supabaseUrl, supabaseKey);
+
+  const [rows, setRows] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    const fetchToday = async () => {
+      setLoading(true);
+      setError('');
+      const today = new Date();
+      const start = new Date(today.getFullYear(), today.getMonth(), today.getDate());
+      const end = new Date(start);
+      end.setDate(end.getDate() + 1);
+      const { data, error: err } = await supabase
+        .from('floor_traffic')
+        .select('*')
+        .gte('visit_time', start.toISOString())
+        .lt('visit_time', end.toISOString())
+        .order('visit_time', { ascending: true });
+
+      if (err) {
+        console.error(err);
+        setError('Failed to load traffic');
+        setRows([]);
+      } else {
+        setRows(data || []);
+      }
+      setLoading(false);
+    };
+    fetchToday();
+  }, [supabase]);
+
+  const responded = rows.filter(r => r.last_response_time).length;
+  const unresponded = rows.length - responded;
+
+  const kpiClass =
+    'flex-1 bg-white shadow rounded-2xl p-4 hover:-translate-y-1 transition-transform';
+
+  return (
+    <div className="p-4 space-y-6">
+      <h1 className="text-3xl font-bold">Floor Traffic</h1>
+      <div className="flex flex-col sm:flex-row gap-4">
+        <div className={kpiClass}>
+          <p className="text-gray-500">Total Visitors Today</p>
+          <p className="text-2xl font-semibold">{rows.length}</p>
+        </div>
+        <div className={kpiClass}>
+          <p className="text-gray-500">Responded Leads</p>
+          <p className="text-2xl font-semibold">{responded}</p>
+        </div>
+        <div className={kpiClass}>
+          <p className="text-gray-500">Unresponded Leads</p>
+          <p className="text-2xl font-semibold">{unresponded}</p>
+        </div>
+      </div>
+
+      {error && (
+        <div className="p-4 bg-red-100 text-red-700 rounded">{error}</div>
+      )}
+
+      {loading ? (
+        <div className="p-4">Loading…</div>
+      ) : (
+        <FloorTrafficTable rows={rows} />
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add FloorTrafficPage and subcomponent FloorTrafficTable
- connect to Supabase for todays floor traffic entries
- add KPI summaries and sortable table
- hook the new page into the router
- install `@supabase/supabase-js`

## Testing
- `npm run lint`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68683ec40ed88322b4aeebecc7ea8422