### PR TITLE
Fix inventory API error handling

### DIFF
--- a/app/routers/inventory.py
+++ b/app/routers/inventory.py
@@ -44,7 +44,10 @@ def list_inventory(
     if drivetrain:
         query = query.eq("drivetrain", drivetrain)
 
-    res = query.execute()
+    try:
+        res = query.execute()
+    except APIError as e:
+        raise HTTPException(status_code=400, detail=e.message)
     return res.data
 
 # Support '/api/inventory' without trailing slash


### PR DESCRIPTION
## Summary
- handle Supabase API errors when listing inventory

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868479dcbac83228d0ea083bb612589