### PR TITLE
Fix missing Supabase env vars in frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,12 +32,15 @@ install the necessary dev dependencies (`tailwindcss`, `postcss` and
 
 ## Environment Variables
 
-The FastAPI services expect `SUPABASE_URL` and `SUPABASE_KEY` to be set. `CORS_ORIGINS` controls the allowed origins for both servers.
+The FastAPI services expect `SUPABASE_URL` and `SUPABASE_KEY` to be set. `CORS_ORIGINS` controls the allowed origins for both servers. The React frontend looks for `VITE_API_BASE_URL`, `VITE_SUPABASE_URL` and `VITE_SUPABASE_KEY`.
 
 ```env
 SUPABASE_URL=<your-supabase-url>
 SUPABASE_KEY=<your-supabase-key>
 CORS_ORIGINS=https://aiventa-crm.vercel.app,https://aiventa-g3al310q6-brian-dubles-projects.vercel.app
+VITE_API_BASE_URL=http://localhost:8000
+VITE_SUPABASE_URL=<your-supabase-url>
+VITE_SUPABASE_KEY=<your-supabase-key>
 ```
 
 Be sure to omit any trailing slashes from the origins.

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,1 +1,3 @@
 VITE_API_BASE_URL=http://localhost:8000
+VITE_SUPABASE_URL=<your-supabase-url>
+VITE_SUPABASE_KEY=<your-supabase-key>

--- a/frontend/src/pages/FloorTrafficPage.jsx
+++ b/frontend/src/pages/FloorTrafficPage.jsx
@@ -5,7 +5,22 @@ import FloorTrafficTable from '../components/FloorTrafficTable';
 export default function FloorTrafficPage() {
   const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
   const supabaseKey = import.meta.env.VITE_SUPABASE_KEY;
-  const supabase = createClient(supabaseUrl, supabaseKey);
+
+  // Gracefully handle missing env vars to avoid runtime errors
+  const supabase =
+    supabaseUrl && supabaseKey ? createClient(supabaseUrl, supabaseKey) : null;
+
+  if (!supabase) {
+    return (
+      <div className="p-4">
+        <h1 className="text-3xl font-bold">Floor Traffic</h1>
+        <p className="mt-4 text-red-600">
+          Supabase is not configured. Please set VITE_SUPABASE_URL and
+          VITE_SUPABASE_KEY.
+        </p>
+      </div>
+    );
+  }
 
   const [rows, setRows] = useState([]);
   const [loading, setLoading] = useState(false);


### PR DESCRIPTION
## Summary
- gracefully handle missing Supabase settings in FloorTrafficPage
- document required Vite env vars
- add Supabase placeholders to frontend env example

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68685d0d1a988322be554ffa6e4a170b