### PR TITLE
Fix and enhance leads page styling

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -7,9 +7,10 @@
   line-height: 1.5;
   font-weight: 400;
 
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
+  /* Force light theme colors so text remains visible on white sections */
+  color-scheme: light;
+  color: #213547;
+  background-color: #F7FAFC; /* light gray for subtle contrast */
 
   font-synthesis: none;
   text-rendering: optimizeLegibility;

--- a/frontend/src/routes/LeadLog.jsx
+++ b/frontend/src/routes/LeadLog.jsx
@@ -114,7 +114,7 @@ export default function LeadLog() {
             </thead>
             <tbody>
               {prioritized.map(l => (
-                <tr key={l.id}>
+                <tr key={l.id} className="odd:bg-gray-50 hover:bg-gray-100">
                   <td className="p-2 whitespace-nowrap">{l.name}</td>
                   <td className="p-2 whitespace-nowrap">{l.email}</td>
                   <td className="p-2 whitespace-nowrap">{formatDate(l.last_lead_response_at)}</td>
@@ -151,7 +151,7 @@ export default function LeadLog() {
             </thead>
             <tbody>
               {leads.map(l => (
-                <tr key={l.id}>
+                <tr key={l.id} className="odd:bg-gray-50 hover:bg-gray-100">
                   <td className="p-2 whitespace-nowrap">{l.name}</td>
                   <td className="p-2 whitespace-nowrap">{l.email}</td>
                   <td className="p-2 whitespace-nowrap">{formatDate(l.created_at)}</td>
@@ -176,7 +176,7 @@ export default function LeadLog() {
             </thead>
             <tbody>
               {awaiting.map(l => (
-                <tr key={l.id} className="bg-red-100">
+                <tr key={l.id} className="bg-red-100 odd:bg-red-50 hover:bg-red-200">
                   <td className="p-2 whitespace-nowrap">{l.name}</td>
                   <td className="p-2 whitespace-nowrap">{l.email}</td>
                   <td className="p-2 whitespace-nowrap">{formatDate(l.last_lead_response_at)}</td>


### PR DESCRIPTION
## Summary
- enforce light color scheme so text is visible against white sections
- add zebra striping and hover effects to the leads tables

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68687be1c9dc83228893effd8579de77