### PR TITLE
Fix floor traffic page fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ VITE_SUPABASE_KEY=<your-supabase-key>
 
 Be sure to omit any trailing slashes from the origins.
 
+If `VITE_SUPABASE_URL` and `VITE_SUPABASE_KEY` are not provided, the
+floor-traffic page will automatically fall back to fetching data from the API
+server at `/api/floor-traffic`.
+
 ## Using the Supabase API
 
 When calling Supabase REST endpoints directly, include both the `apikey` and

--- a/frontend/src/pages/FloorTrafficPage.jsx
+++ b/frontend/src/pages/FloorTrafficPage.jsx
@@ -5,58 +5,54 @@ import FloorTrafficTable from '../components/FloorTrafficTable';
 export default function FloorTrafficPage() {
   const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
   const supabaseKey = import.meta.env.VITE_SUPABASE_KEY;
+  const API_BASE = import.meta.env.PROD
+    ? import.meta.env.VITE_API_BASE_URL
+    : '/api';
 
   // Gracefully handle missing env vars to avoid runtime errors
   const supabase =
     supabaseUrl && supabaseKey ? createClient(supabaseUrl, supabaseKey) : null;
-
-
-  if (!supabase) {
-    return (
-      <div className="p-4">
-        <h1 className="text-3xl font-bold">Floor Traffic</h1>
-        <p className="mt-4 text-red-600">
-          Supabase is not configured. Please set VITE_SUPABASE_URL and
-          VITE_SUPABASE_KEY.
-        </p>
-      </div>
-    );
-  }
 
   const [rows, setRows] = useState([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
 
   useEffect(() => {
-    if (!supabase) {
-      return;
-    }
-
     const fetchToday = async () => {
       setLoading(true);
       setError('');
-      const today = new Date();
-      const start = new Date(today.getFullYear(), today.getMonth(), today.getDate());
-      const end = new Date(start);
-      end.setDate(end.getDate() + 1);
-      const { data, error: err } = await supabase
-        .from('floor_traffic_customers')
-        .select('*')
-        .gte('visit_time', start.toISOString())
-        .lt('visit_time', end.toISOString())
-        .order('visit_time', { ascending: true });
 
-      if (err) {
+      try {
+        if (supabase) {
+          const today = new Date();
+          const start = new Date(today.getFullYear(), today.getMonth(), today.getDate());
+          const end = new Date(start);
+          end.setDate(end.getDate() + 1);
+          const { data, error: err } = await supabase
+            .from('floor_traffic_customers')
+            .select('*')
+            .gte('visit_time', start.toISOString())
+            .lt('visit_time', end.toISOString())
+            .order('visit_time', { ascending: true });
+          if (err) throw err;
+          setRows(data || []);
+        } else {
+          const res = await fetch(`${API_BASE}/floor-traffic`);
+          if (!res.ok) throw new Error('Failed to load traffic');
+          const data = await res.json();
+          setRows(data || []);
+        }
+      } catch (err) {
         console.error(err);
         setError('Failed to load traffic');
         setRows([]);
-      } else {
-        setRows(data || []);
+      } finally {
+        setLoading(false);
       }
-      setLoading(false);
     };
+
     fetchToday();
-  }, [supabase]);
+  }, [supabase, API_BASE]);
 
   const responded = rows.filter(r => r.last_response_time).length;
   const unresponded = rows.length - responded;
@@ -69,9 +65,10 @@ export default function FloorTrafficPage() {
       <h1 className="text-3xl font-bold">Floor Traffic</h1>
 
       {!supabase && (
-        <p className="mt-4 text-red-600">
-          Supabase is not configured. Please set VITE_SUPABASE_URL and
-          VITE_SUPABASE_KEY.
+        <p className="mt-4 text-yellow-700">
+          Supabase is not configured. Falling back to the API server.
+          Ensure VITE_SUPABASE_URL and VITE_SUPABASE_KEY are set if you wish to
+          query Supabase directly.
         </p>
       )}
 


### PR DESCRIPTION
## Summary
- handle missing Supabase vars on the floor traffic page by falling back to `/api/floor-traffic`
- document fallback behaviour in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68687d91800483228606ce727ffddd1b