### PR TITLE
Add activity metrics to floor traffic

### DIFF
--- a/app/routers/activities.py
+++ b/app/routers/activities.py
@@ -5,6 +5,40 @@ from app.models import Activity, ActivityCreate, ActivityUpdate
 
 router = APIRouter()
 
+
+@router.get("/today-metrics")
+def today_metrics():
+    """Return counts of today's activities grouped by type."""
+    from datetime import date, datetime, timedelta
+
+    today = date.today()
+    start = datetime.combine(today, datetime.min.time())
+    end = start + timedelta(days=1)
+
+    try:
+        res = (
+            supabase.table("activities")
+            .select("type")
+            .gte("created_at", start.isoformat())
+            .lt("created_at", end.isoformat())
+            .execute()
+        )
+    except APIError as e:
+        raise HTTPException(status_code=500, detail=e.message)
+
+    data = res.data or []
+    counts = {"sales_calls": 0, "text_messages": 0, "appointments_set": 0}
+    for row in data:
+        t = str(row.get("type", "")).lower()
+        if "call" in t:
+            counts["sales_calls"] += 1
+        elif "text" in t:
+            counts["text_messages"] += 1
+        elif "appointment" in t:
+            counts["appointments_set"] += 1
+
+    return counts
+
 @router.get("/", response_model=list[Activity])
 def list_activities():
     res = supabase.table("activities").select("*").execute()

--- a/tests/test_activities.py
+++ b/tests/test_activities.py
@@ -1,0 +1,30 @@
+from fastapi.testclient import TestClient
+from unittest.mock import MagicMock, patch
+from app.main import app
+
+client = TestClient(app)
+
+
+def test_today_metrics():
+    sample = [
+        {"type": "call"},
+        {"type": "text"},
+        {"type": "appointment"},
+        {"type": "call"},
+    ]
+
+    exec_result = MagicMock(data=sample, error=None)
+    mock_table = MagicMock()
+    mock_table.select.return_value.gte.return_value.lt.return_value.execute.return_value = exec_result
+    mock_supabase = MagicMock()
+    mock_supabase.table.return_value = mock_table
+
+    with patch("app.routers.activities.supabase", mock_supabase):
+        response = client.get("/api/activities/today-metrics")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "sales_calls": 2,
+        "text_messages": 1,
+        "appointments_set": 1,
+    }


### PR DESCRIPTION
## Summary
- add `/api/activities/today-metrics` to get today's activity counts
- display activity metrics on Floor Traffic page
- combine responded and unresponded lead KPIs into one card
- test the new endpoint

## Testing
- `npm run lint`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6869374221d48322ab88daf52130fbd8