### PR TITLE
Add editing for floor traffic entries

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -120,6 +120,9 @@ class FloorTrafficCustomer(BaseModel):
     email: Optional[EmailStr] = None
     phone: Optional[str] = None
     visit_time: datetime
+    demo: Optional[bool] = None
+    worksheet: Optional[bool] = None
+    customer_offer: Optional[bool] = None
     notes: Optional[str] = None
     created_at: datetime
 
@@ -130,6 +133,9 @@ class FloorTrafficCustomerCreate(BaseModel):
     last_name: str
     email: Optional[EmailStr] = None
     phone: Optional[str] = None
+    demo: Optional[bool] = None
+    worksheet: Optional[bool] = None
+    customer_offer: Optional[bool] = None
     notes: Optional[str] = None
 
     @validator('email', pre=True, always=True)
@@ -146,6 +152,9 @@ class FloorTrafficCustomerUpdate(BaseModel):
     email: Optional[EmailStr] = None
     phone: Optional[str] = None
     visit_time: Optional[datetime] = None
+    demo: Optional[bool] = None
+    worksheet: Optional[bool] = None
+    customer_offer: Optional[bool] = None
     notes: Optional[str] = None
 
 

--- a/frontend/src/components/FloorTrafficModal.jsx
+++ b/frontend/src/components/FloorTrafficModal.jsx
@@ -1,0 +1,117 @@
+import React, { useState, useEffect } from 'react';
+
+export default function FloorTrafficModal({ isOpen, onClose, onSubmit, initialData }) {
+  const [form, setForm] = useState({
+    salesperson: '',
+    first_name: '',
+    last_name: '',
+    email: '',
+    phone: '',
+    vehicle: '',
+    trade: '',
+    demo: false,
+    worksheet: false,
+    customer_offer: false,
+    notes: '',
+  });
+
+  useEffect(() => {
+    if (initialData) {
+      setForm({
+        salesperson: initialData.salesperson || '',
+        first_name: initialData.first_name || '',
+        last_name: initialData.last_name || '',
+        email: initialData.email || '',
+        phone: initialData.phone || '',
+        vehicle: initialData.vehicle || '',
+        trade: initialData.trade || '',
+        demo: !!initialData.demo,
+        worksheet:
+          !!initialData.worksheet ||
+          !!initialData.writeUp ||
+          !!initialData.worksheet_complete ||
+          !!initialData.worksheetComplete ||
+          !!initialData.write_up,
+        customer_offer: !!initialData.customer_offer || !!initialData.customerOffer,
+        notes: initialData.notes || '',
+      });
+    }
+  }, [initialData]);
+
+  if (!isOpen) return null;
+
+  const handleChange = e => {
+    const { name, value, type, checked } = e.target;
+    setForm(f => ({ ...f, [name]: type === 'checkbox' ? checked : value }));
+  };
+
+  const handleSubmit = e => {
+    e.preventDefault();
+    onSubmit(form);
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 overflow-y-auto">
+      <div className="bg-white dark:bg-gray-800 p-6 rounded w-full max-w-xl space-y-4">
+        <h3 className="text-lg font-semibold">Edit Customer</h3>
+        <form onSubmit={handleSubmit} className="space-y-4 max-h-[80vh] overflow-y-auto pr-2">
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <label className="block text-sm mb-1">Salesperson</label>
+              <input name="salesperson" value={form.salesperson} onChange={handleChange} className="w-full border rounded px-2 py-1" />
+            </div>
+            <div>
+              <label className="block text-sm mb-1">Vehicle</label>
+              <input name="vehicle" value={form.vehicle} onChange={handleChange} className="w-full border rounded px-2 py-1" />
+            </div>
+          </div>
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <label className="block text-sm mb-1">First Name</label>
+              <input name="first_name" value={form.first_name} onChange={handleChange} className="w-full border rounded px-2 py-1" />
+            </div>
+            <div>
+              <label className="block text-sm mb-1">Last Name</label>
+              <input name="last_name" value={form.last_name} onChange={handleChange} className="w-full border rounded px-2 py-1" />
+            </div>
+          </div>
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <label className="block text-sm mb-1">Email</label>
+              <input name="email" type="email" value={form.email} onChange={handleChange} className="w-full border rounded px-2 py-1" />
+            </div>
+            <div>
+              <label className="block text-sm mb-1">Phone</label>
+              <input name="phone" value={form.phone} onChange={handleChange} className="w-full border rounded px-2 py-1" />
+            </div>
+          </div>
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <label className="block text-sm mb-1">Trade</label>
+              <input name="trade" value={form.trade} onChange={handleChange} className="w-full border rounded px-2 py-1" />
+            </div>
+            <div className="flex items-center gap-2 mt-5">
+              <label className="flex items-center gap-2">
+                <input type="checkbox" name="demo" checked={form.demo} onChange={handleChange} /> Demo
+              </label>
+              <label className="flex items-center gap-2">
+                <input type="checkbox" name="worksheet" checked={form.worksheet} onChange={handleChange} /> Worksheet
+              </label>
+              <label className="flex items-center gap-2">
+                <input type="checkbox" name="customer_offer" checked={form.customer_offer} onChange={handleChange} /> Offer
+              </label>
+            </div>
+          </div>
+          <div>
+            <label className="block text-sm mb-1">Notes</label>
+            <textarea name="notes" value={form.notes} onChange={handleChange} className="w-full border rounded px-2 py-1 h-24" />
+          </div>
+          <div className="flex justify-end gap-2">
+            <button type="button" onClick={onClose} className="px-3 py-2 border rounded">Cancel</button>
+            <button type="submit" className="px-3 py-2 bg-electricblue text-white rounded">Save</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/FloorTrafficTable.jsx
+++ b/frontend/src/components/FloorTrafficTable.jsx
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
-import { Phone, MessageCircle, Mail } from 'lucide-react';
-
-export default function FloorTrafficTable({ rows }) {
+import { Phone, MessageCircle, Mail, Pencil } from 'lucide-react';
+export default function FloorTrafficTable({ rows, onEdit, onToggle }) {
   const [sortConfig, setSortConfig] = useState({ key: 'visit_time', direction: 'ascending' });
   const [acknowledged, setAcknowledged] = useState(new Set());
 
@@ -31,6 +30,9 @@ export default function FloorTrafficTable({ rows }) {
     { key: 'salesperson', label: 'Salesperson' },
     { key: 'customer_name', label: 'Customer' },
     { key: 'vehicle', label: 'Vehicle' },
+    { key: 'demo', label: 'Demo' },
+    { key: 'worksheet', label: 'Worksheet' },
+    { key: 'customer_offer', label: 'Customer Offer' },
     { key: 'notes', label: 'Notes' },
     { key: 'phone', label: 'Phone' }
   ];
@@ -46,7 +48,20 @@ export default function FloorTrafficTable({ rows }) {
       <tr key={row.id} className={rowClasses} role="row" onClick={() => handleRowClick(row.id)}>
         {headers.map(h => (
           <td key={h.key} className="p-2" role="cell" data-label={h.label}>
-            {h.key === 'visit_time' ? new Date(row[h.key]).toLocaleTimeString() : String(row[h.key] ?? '')}
+            {h.key === 'visit_time' ? (
+              new Date(row[h.key]).toLocaleTimeString()
+            ) : h.key === 'demo' || h.key === 'worksheet' || h.key === 'customer_offer' ? (
+              <input
+                type="checkbox"
+                checked={Boolean(row[h.key])}
+                onChange={e => {
+                  e.stopPropagation();
+                  onToggle && onToggle(row.id, h.key, e.target.checked);
+                }}
+              />
+            ) : (
+              String(row[h.key] ?? '')
+            )}
           </td>
         ))}
         <td className="p-2 space-x-1" role="cell">
@@ -79,6 +94,16 @@ export default function FloorTrafficTable({ rows }) {
             }}
           >
             <Mail className="h-4 w-4" />
+          </button>
+          <button
+            aria-label="Edit"
+            className="rounded-full p-2 hover:bg-gray-100 transition"
+            onClick={e => {
+              e.stopPropagation();
+              onEdit && onEdit(row);
+            }}
+          >
+            <Pencil className="h-4 w-4" />
           </button>
         </td>
       </tr>

--- a/tests/test_floor_traffic.py
+++ b/tests/test_floor_traffic.py
@@ -8,7 +8,7 @@ client = TestClient(app)
 
 def test_get_today_floor_traffic():
     sample = [{
-        "id": 1,
+        "id": "1",
         "salesperson": "Bob",
         "customer_name": "Alice",
         "first_name": None,
@@ -16,6 +16,9 @@ def test_get_today_floor_traffic():
         "email": None,
         "phone": None,
         "visit_time": "2024-01-01T09:00:00",
+        "demo": None,
+        "worksheet": None,
+        "customer_offer": None,
         "notes": None,
         "created_at": "2024-01-01T09:00:00"
     }]
@@ -35,7 +38,7 @@ def test_get_today_floor_traffic():
 
 def test_create_floor_traffic():
     sample = {
-        "id": 1,
+        "id": "1",
         "salesperson": "Bob",
         "customer_name": "Alice",
         "first_name": None,
@@ -43,6 +46,9 @@ def test_create_floor_traffic():
         "email": None,
         "phone": None,
         "visit_time": "2024-01-01T10:00:00",
+        "demo": None,
+        "worksheet": None,
+        "customer_offer": None,
         "notes": None,
         "created_at": "2024-01-01T10:00:00",
     }
@@ -59,6 +65,8 @@ def test_create_floor_traffic():
         "customerName": sample["customer_name"],
         "visit_time": sample["visit_time"],
         "customer_name": sample["customer_name"],
+        "first_name": "Alice",
+        "last_name": "Smith",
     }
 
     with patch("app.routers.floor_traffic.supabase", mock_supabase):
@@ -69,4 +77,38 @@ def test_create_floor_traffic():
         )
 
     assert response.status_code == 201
+    assert response.json() == sample
+
+
+def test_update_floor_traffic():
+    sample = {
+        "id": "1",
+        "salesperson": "Bob",
+        "customer_name": "Alice",
+        "first_name": None,
+        "last_name": None,
+        "email": None,
+        "phone": None,
+        "visit_time": "2024-01-01T10:00:00",
+        "demo": None,
+        "worksheet": None,
+        "customer_offer": None,
+        "notes": "Updated",
+        "created_at": "2024-01-01T10:00:00",
+    }
+
+    exec_result = MagicMock(data=[sample], error=None)
+    mock_table = MagicMock()
+    mock_table.update.return_value.eq.return_value.execute.return_value = exec_result
+    mock_supabase = MagicMock()
+    mock_supabase.table.return_value = mock_table
+
+    with patch("app.routers.floor_traffic.supabase", mock_supabase):
+        response = client.put(
+            "/api/floor-traffic/1",
+            content=json.dumps({"notes": "Updated"}),
+            headers={"Content-Type": "application/json"},
+        )
+
+    assert response.status_code == 200
     assert response.json() == sample


### PR DESCRIPTION
## Summary
- support demo, worksheet and customer_offer fields on floor log models
- add API endpoint to update floor traffic entries
- track demo/worksheet/offer metrics in FloorTrafficPage
- allow editing and checkbox toggles in FloorTrafficTable
- add FloorTrafficModal component
- update tests for new fields

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68697024e8dc8322b70240a0d565598f