### PR TITLE
Improve floor traffic KPIs and table UI

### DIFF
--- a/frontend/src/components/FloorTrafficModal.jsx
+++ b/frontend/src/components/FloorTrafficModal.jsx
@@ -12,6 +12,7 @@ export default function FloorTrafficModal({ isOpen, onClose, onSubmit, initialDa
     demo: false,
     worksheet: false,
     customer_offer: false,
+    sold: false,
     notes: '',
   });
 
@@ -33,6 +34,7 @@ export default function FloorTrafficModal({ isOpen, onClose, onSubmit, initialDa
           !!initialData.worksheetComplete ||
           !!initialData.write_up,
         customer_offer: !!initialData.customer_offer || !!initialData.customerOffer,
+        sold: !!initialData.sold,
         notes: initialData.notes || '',
       });
     }
@@ -99,6 +101,9 @@ export default function FloorTrafficModal({ isOpen, onClose, onSubmit, initialDa
               </label>
               <label className="flex items-center gap-2">
                 <input type="checkbox" name="customer_offer" checked={form.customer_offer} onChange={handleChange} /> Offer
+              </label>
+              <label className="flex items-center gap-2">
+                <input type="checkbox" name="sold" checked={form.sold} onChange={handleChange} /> Sold
               </label>
             </div>
           </div>

--- a/frontend/src/components/FloorTrafficTable.jsx
+++ b/frontend/src/components/FloorTrafficTable.jsx
@@ -34,6 +34,7 @@ export default function FloorTrafficTable({ rows, onEdit, onToggle }) {
     { key: 'demo', label: 'Demo' },
     { key: 'worksheet', label: 'Worksheet' },
     { key: 'customer_offer', label: 'Customer Offer' },
+    { key: 'sold', label: 'Sold' },
     { key: 'notes', label: 'Notes' },
     { key: 'phone', label: 'Phone' }
   ];
@@ -44,7 +45,10 @@ export default function FloorTrafficTable({ rows, onEdit, onToggle }) {
 
   const renderRow = row => {
     const isUnresponded = !row.last_response_time && !acknowledged.has(row.id);
-    const rowClasses = `flex flex-col sm:table-row ${isUnresponded ? 'animate-pulse bg-red-50' : ''}`;
+    let rowClasses = 'flex flex-col sm:table-row';
+    if (isUnresponded) rowClasses += ' animate-pulse bg-red-50';
+    if (row.time_out) rowClasses += ' bg-yellow-100';
+    if (row.sold) rowClasses += ' bg-green-100';
     return (
       <tr key={row.id} className={rowClasses} role="row" onClick={() => handleRowClick(row.id)}>
         {headers.map(h => (
@@ -63,7 +67,7 @@ export default function FloorTrafficTable({ rows, onEdit, onToggle }) {
                   }}
                 />
               )
-            ) : h.key === 'demo' || h.key === 'worksheet' || h.key === 'customer_offer' ? (
+            ) : h.key === 'demo' || h.key === 'worksheet' || h.key === 'customer_offer' || h.key === 'sold' ? (
               <input
                 type="checkbox"
                 checked={Boolean(row[h.key])}

--- a/frontend/src/pages/FloorTrafficPage.jsx
+++ b/frontend/src/pages/FloorTrafficPage.jsx
@@ -107,6 +107,7 @@ export default function FloorTrafficPage() {
   const unresponded = rows.length - responded;
 
   const totalCustomers = rows.length;
+  const inStoreCount = rows.filter(r => !r.time_out).length;
   const demoCount = rows.filter(r => r.demo).length;
   const worksheetCount = rows.filter(
     r => r.writeUp || r.worksheet || r.worksheet_complete || r.worksheetComplete || r.write_up
@@ -180,6 +181,7 @@ export default function FloorTrafficPage() {
         <div className={kpiClass}>
           <p className="text-gray-500">Total Visitors Today</p>
           <p className="text-2xl font-semibold">{totalCustomers}</p>
+          <p className="text-sm text-gray-600">{inStoreCount} currently in store</p>
           <ul className="mt-2 space-y-1 text-sm text-gray-600">
             <li>
               {totalCustomers} customers ({pct(totalCustomers)}%)


### PR DESCRIPTION
## Summary
- show customers currently in store in KPI card
- highlight rows when customer timed out or sold
- add `Sold` checkbox and editing support

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68697ad3717c8322a9e28d29f644b289