### PR TITLE
Add customer search page

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -5,6 +5,7 @@ import { BrowserRouter as Router, Routes, Route, Link } from "react-router-dom";
 import LeadLog                from "./routes/LeadLog";
 import UsersPage              from "./routes/UsersPage";
 import InventoryPage          from "./routes/InventoryPage";
+import CustomersPage          from "./routes/CustomersPage";
 import { Toaster }            from 'react-hot-toast';
 import ActivityTimeline       from "./components/ActivityTimeline";
 import CreateLeadForm         from "./components/CreateLeadForm";
@@ -70,6 +71,7 @@ export default function App() {
             ['/', 'Home'],
             ['/leads', 'Lead Log'],
             ['/leads/new', 'New Lead'],
+            ['/customers', 'Customers'],
             ['/users', 'Users'],
             ['/inventory', 'Inventory'],
             ['/recon', 'Recon'],
@@ -90,6 +92,7 @@ export default function App() {
           <Route path="/" element={<Home />} />
           <Route path="/leads" element={<LeadLog />} />
           <Route path="/leads/new" element={<CreateLeadForm />} />
+          <Route path="/customers" element={<CustomersPage />} />
           <Route path="/users" element={<UsersPage />} />
           <Route path="/inventory" element={<InventoryPage />} />
           <Route path="/recon" element={<ReconPage />} />

--- a/frontend/src/routes/CustomersPage.jsx
+++ b/frontend/src/routes/CustomersPage.jsx
@@ -51,7 +51,7 @@ export default function CustomersPage() {
       ) : (
         <div className="overflow-x-auto">
           <table className="min-w-full divide-y">
-            <thead className="bg-slategray text-white">
+            <thead className="bg-slate-700 text-white">
               <tr>
                 <th className="p-2 text-left">Name</th>
                 <th className="p-2 text-left">Email</th>

--- a/frontend/src/routes/CustomersPage.jsx
+++ b/frontend/src/routes/CustomersPage.jsx
@@ -1,0 +1,99 @@
+import React, { useEffect, useState } from 'react'
+import { Phone, MessageCircle, Mail } from 'lucide-react'
+
+export default function CustomersPage() {
+  const API_BASE = import.meta.env.VITE_API_BASE_URL || '/api'
+
+  const [search, setSearch] = useState('')
+  const [debounced, setDebounced] = useState('')
+  const [customers, setCustomers] = useState([])
+  const [isLoading, setIsLoading] = useState(false)
+
+  useEffect(() => {
+    const t = setTimeout(() => setDebounced(search), 300)
+    return () => clearTimeout(t)
+  }, [search])
+
+  useEffect(() => {
+    const fetchCustomers = async () => {
+      setIsLoading(true)
+      try {
+        const params = new URLSearchParams()
+        if (debounced) params.append('q', debounced)
+        const res = await fetch(`${API_BASE}/contacts/?${params.toString()}`)
+        if (!res.ok) throw new Error('Failed to load customers')
+        const data = await res.json()
+        setCustomers(Array.isArray(data) ? data : [])
+      } catch (err) {
+        console.error(err)
+        setCustomers([])
+      } finally {
+        setIsLoading(false)
+      }
+    }
+    fetchCustomers()
+  }, [debounced, API_BASE])
+
+  return (
+    <div className="p-4 space-y-4">
+      <h2 className="text-2xl font-bold">Customers</h2>
+
+      <input
+        type="text"
+        placeholder="Search by name, email or phone"
+        className="border rounded px-3 py-2 w-64"
+        value={search}
+        onChange={e => setSearch(e.target.value)}
+      />
+
+      {isLoading ? (
+        <div className="text-center">Loading...</div>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="min-w-full divide-y">
+            <thead className="bg-slategray text-white">
+              <tr>
+                <th className="p-2 text-left">Name</th>
+                <th className="p-2 text-left">Email</th>
+                <th className="p-2 text-left">Phone</th>
+                <th className="p-2 text-left">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {customers.map(c => (
+                <tr key={c.id} className="odd:bg-gray-50 hover:bg-gray-100">
+                  <td className="p-2 whitespace-nowrap">{c.name}</td>
+                  <td className="p-2 whitespace-nowrap">{c.email}</td>
+                  <td className="p-2 whitespace-nowrap">{c.phone}</td>
+                  <td className="p-2 space-x-1 whitespace-nowrap">
+                    <button
+                      aria-label={`Call ${c.name}`}
+                      className="rounded-full p-2 hover:bg-gray-100 transition"
+                      onClick={() => { window.location.href = `tel:${c.phone ?? ''}` }}
+                    >
+                      <Phone className="h-4 w-4" />
+                    </button>
+                    <button
+                      aria-label={`Text ${c.name}`}
+                      className="rounded-full p-2 hover:bg-gray-100 transition"
+                      onClick={() => { window.location.href = `sms:${c.phone ?? ''}` }}
+                    >
+                      <MessageCircle className="h-4 w-4" />
+                    </button>
+                    <button
+                      aria-label={`Email ${c.name}`}
+                      className="rounded-full p-2 hover:bg-gray-100 transition"
+                      onClick={() => { window.location.href = `mailto:${c.email ?? ''}` }}
+                    >
+                      <Mail className="h-4 w-4" />
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/tests/test_contacts.py
+++ b/tests/test_contacts.py
@@ -1,0 +1,35 @@
+from fastapi.testclient import TestClient
+from unittest.mock import MagicMock, patch
+from app.main import app
+import json
+
+client = TestClient(app)
+
+
+def test_search_contacts():
+    sample = [{
+        "id": "1",
+        "name": "Alice",
+        "email": "a@example.com",
+        "phone": "123",
+        "lead_id": None,
+        "account_id": None,
+    }]
+    exec_result = MagicMock(data=sample, error=None)
+
+    mock_query = MagicMock()
+    mock_query.ilike.return_value = mock_query
+    mock_query.execute.return_value = exec_result
+
+    mock_table = MagicMock()
+    mock_table.select.return_value = mock_query
+    mock_supabase = MagicMock()
+    mock_supabase.table.return_value = mock_table
+
+    with patch("app.routers.contacts.supabase", mock_supabase):
+        response = client.get("/api/contacts/?q=Ali")
+
+    assert response.status_code == 200
+    assert response.json() == sample
+    mock_query.ilike.assert_any_call("name", "%Ali%")
+

--- a/tests/test_contacts.py
+++ b/tests/test_contacts.py
@@ -1,8 +1,6 @@
 from fastapi.testclient import TestClient
 from unittest.mock import MagicMock, patch
 from app.main import app
-import json
-
 client = TestClient(app)
 
 


### PR DESCRIPTION
## Summary
- extend contacts router with optional search filters
- add new `CustomersPage` in the frontend with search and inline actions
- expose the page via navigation and routes
- test contact search endpoint

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68698d91cdf88322b0b5501c069d7825