### PR TITLE
Update floor log flashing logic

### DIFF
--- a/frontend/src/components/FloorTrafficTable.jsx
+++ b/frontend/src/components/FloorTrafficTable.jsx
@@ -44,9 +44,14 @@ export default function FloorTrafficTable({ rows, onEdit, onToggle }) {
   };
 
   const renderRow = row => {
-    const isUnresponded = !row.last_response_time && !acknowledged.has(row.id);
+    const visitTime = row.visit_time ? new Date(row.visit_time) : null;
+    const hoursOnLog = visitTime
+      ? (Date.now() - visitTime.getTime()) / (1000 * 60 * 60)
+      : 0;
+    const needsAttention =
+      !row.time_out && hoursOnLog >= 4 && !acknowledged.has(row.id);
     let rowClasses = 'flex flex-col sm:table-row';
-    if (isUnresponded) rowClasses += ' animate-pulse';
+    if (needsAttention) rowClasses += ' animate-pulse';
     if (row.sold) rowClasses += ' bg-green-100';
     else if (row.time_out) rowClasses += ' bg-yellow-100';
     else rowClasses += ' bg-red-100';


### PR DESCRIPTION
## Summary
- change `FloorTrafficTable` to only flash rows when a customer is still on the log with no timeout after 4 hours

## Testing
- `pytest -q`
- `npm --prefix frontend run build`

------
https://chatgpt.com/codex/tasks/task_e_6869eaeb5e548322983705420b479cdc