### PR TITLE
Fix floor traffic time out persistence

### DIFF
--- a/models/FloorTrafficModel.js
+++ b/models/FloorTrafficModel.js
@@ -20,12 +20,23 @@ export default class FloorTrafficModel {
    * Assigns it a simple incremental `id`.
    */
   static async create(entry) {
-    const newLog = { 
-      id: logs.length + 1, 
-      ...entry, 
-      createdAt: new Date().toISOString() 
+    const newLog = {
+      id: logs.length + 1,
+      ...entry,
+      createdAt: new Date().toISOString()
     };
     logs.push(newLog);
     return newLog;
+  }
+
+  /**
+   * Update an existing log entry by id.
+   * Returns the updated log or null if not found.
+   */
+  static async update(id, fields) {
+    const index = logs.findIndex(l => l.id === Number(id));
+    if (index === -1) return null;
+    logs[index] = { ...logs[index], ...fields };
+    return logs[index];
   }
 }

--- a/routes/floorTraffic.js
+++ b/routes/floorTraffic.js
@@ -79,4 +79,18 @@ router.post('/floor-traffic', async (req, res, next) => {
   }
 });
 
+/**
+ * PUT /api/floor-traffic/:id
+ * Update an existing floor-traffic entry.
+ */
+router.put('/floor-traffic/:id', async (req, res, next) => {
+  try {
+    const updated = await FloorTrafficModel.update(req.params.id, req.body);
+    if (!updated) return res.status(404).json({ message: 'Not Found' });
+    return res.json(updated);
+  } catch (err) {
+    return next(err);
+  }
+});
+
 export default router;


### PR DESCRIPTION
## Summary
- add update functionality to FloorTrafficModel
- implement PUT `/api/floor-traffic/:id` route so time_out changes persist

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869eb45c014832298384a2b02329b3e