### PR TITLE
Add individual customer pages

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -6,6 +6,7 @@ import LeadLog                from "./routes/LeadLog";
 import UsersPage              from "./routes/UsersPage";
 import InventoryPage          from "./routes/InventoryPage";
 import CustomersPage          from "./routes/CustomersPage";
+import CustomerCard          from "./routes/CustomerCard";
 import { Toaster }            from 'react-hot-toast';
 import ActivityTimeline       from "./components/ActivityTimeline";
 import CreateLeadForm         from "./components/CreateLeadForm";
@@ -93,6 +94,7 @@ export default function App() {
           <Route path="/leads" element={<LeadLog />} />
           <Route path="/leads/new" element={<CreateLeadForm />} />
           <Route path="/customers" element={<CustomersPage />} />
+          <Route path="/customers/:id" element={<CustomerCard />} />
           <Route path="/users" element={<UsersPage />} />
           <Route path="/inventory" element={<InventoryPage />} />
           <Route path="/recon" element={<ReconPage />} />

--- a/frontend/src/routes/CustomerCard.jsx
+++ b/frontend/src/routes/CustomerCard.jsx
@@ -1,0 +1,51 @@
+import React, { useEffect, useState } from 'react';
+import { useParams, Link } from 'react-router-dom';
+
+export default function CustomerCard() {
+  const { id } = useParams();
+  const API_BASE = import.meta.env.VITE_API_BASE_URL || '/api';
+
+  const [customer, setCustomer] = useState(null);
+  const [lead, setLead] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchCustomer = async () => {
+      try {
+        const res = await fetch(`${API_BASE}/contacts/${id}`);
+        if (!res.ok) throw new Error('Failed to load customer');
+        const data = await res.json();
+        setCustomer(data);
+        if (data.lead_id) {
+          const lr = await fetch(`${API_BASE}/leads/${data.lead_id}`);
+          if (lr.ok) {
+            setLead(await lr.json());
+          }
+        }
+      } catch (err) {
+        console.error(err);
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchCustomer();
+  }, [id, API_BASE]);
+
+  if (loading) return <div>Loading...</div>;
+  if (!customer) return <div>Customer not found</div>;
+
+  return (
+    <div className="p-4 space-y-4">
+      <Link to="/customers" className="text-blue-600 hover:underline">
+        &larr; Back to Customers
+      </Link>
+      <div className="bg-white shadow rounded p-4 space-y-2">
+        <h2 className="text-2xl font-bold">{customer.name}</h2>
+        {customer.email && <p>Email: {customer.email}</p>}
+        {customer.phone && <p>Phone: {customer.phone}</p>}
+        {lead?.vehicle_interest && <p>Vehicle Interest: {lead.vehicle_interest}</p>}
+        {lead?.trade_vehicle && <p>Trade Vehicle: {lead.trade_vehicle}</p>}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/routes/CustomersPage.jsx
+++ b/frontend/src/routes/CustomersPage.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react'
+import { Link } from 'react-router-dom'
 import { Phone, MessageCircle, Mail } from 'lucide-react'
 
 export default function CustomersPage() {
@@ -62,7 +63,11 @@ export default function CustomersPage() {
             <tbody>
               {customers.map(c => (
                 <tr key={c.id} className="odd:bg-gray-50 hover:bg-gray-100">
-                  <td className="p-2 whitespace-nowrap">{c.name}</td>
+                  <td className="p-2 whitespace-nowrap">
+                    <Link to={`/customers/${c.id}`} className="text-blue-600 hover:underline">
+                      {c.name}
+                    </Link>
+                  </td>
                   <td className="p-2 whitespace-nowrap">{c.email}</td>
                   <td className="p-2 whitespace-nowrap">{c.phone}</td>
                   <td className="p-2 space-x-1 whitespace-nowrap">

--- a/tests/test_contacts.py
+++ b/tests/test_contacts.py
@@ -31,3 +31,30 @@ def test_search_contacts():
     assert response.json() == sample
     mock_query.ilike.assert_any_call("name", "%Ali%")
 
+
+def test_get_contact():
+    sample = {
+        "id": "1",
+        "name": "Alice",
+        "email": "a@example.com",
+        "phone": "123",
+        "lead_id": 2,
+        "account_id": None,
+    }
+    exec_result = MagicMock(data=sample, error=None)
+
+    mock_select = MagicMock()
+    mock_select.eq.return_value.maybe_single.return_value.execute.return_value = exec_result
+
+    mock_table = MagicMock()
+    mock_table.select.return_value = mock_select
+    mock_supabase = MagicMock()
+    mock_supabase.table.return_value = mock_table
+
+    with patch("app.routers.contacts.supabase", mock_supabase):
+        response = client.get("/api/contacts/1")
+
+    assert response.status_code == 200
+    assert response.json() == sample
+    mock_select.eq.assert_called_with("id", 1)
+


### PR DESCRIPTION
## Summary
- make customer names link to a new detail page
- add `CustomerCard` page that loads contact and lead info
- expose the route in the router
- test fetching a single contact

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ababf682c8322a7fce8698b69e008