### PR TITLE
Add AI chat integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ CORS_ORIGINS=https://aiventa-crm.vercel.app,https://aiventa-g3al310q6-brian-dubl
 VITE_API_BASE_URL=http://localhost:8000
 VITE_SUPABASE_URL=<your-supabase-url>
 VITE_SUPABASE_KEY=<your-supabase-key>
+OPENAI_API_KEY=<your-openai-key>
 ```
 
 Be sure to omit any trailing slashes from the origins.

--- a/app/main.py
+++ b/app/main.py
@@ -12,6 +12,7 @@ from app.routers.contacts        import router as contacts_router
 from app.routers.opportunities   import router as opportunities_router
 from app.routers.activities      import router as activities_router
 from app.routers import inventory  # inventory router mounted under /api/inventory
+from app.routers.chat            import router as chat_router
 
 app = FastAPI(title="aiVenta CRM API")
 
@@ -62,6 +63,7 @@ app.include_router(
     prefix="/api/inventory",
     tags=["inventory"],
 )
+app.include_router(chat_router, prefix="/api/chat", tags=["chat"])
 
 # 4️⃣ Serve your React app for all other GETs
 app.mount(

--- a/app/routers/chat.py
+++ b/app/routers/chat.py
@@ -1,0 +1,26 @@
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+import os
+import openai
+
+openai.api_key = os.environ.get("OPENAI_API_KEY")
+
+router = APIRouter()
+
+class ChatRequest(BaseModel):
+    message: str
+
+@router.post("/")
+async def chat(req: ChatRequest):
+    if not openai.api_key:
+        raise HTTPException(500, "OpenAI API key not configured")
+    try:
+        resp = await openai.ChatCompletion.acreate(
+            model="gpt-3.5-turbo",
+            messages=[{"role": "user", "content": req.message}],
+            temperature=0.3,
+        )
+        return {"answer": resp.choices[0].message.content}
+    except Exception as e:
+        raise HTTPException(500, str(e))
+

--- a/env.example
+++ b/env.example
@@ -2,3 +2,4 @@ SUPABASE_URL=<your-supabase-url>
 SUPABASE_KEY=<your-supabase-key>
 # Comma separated list of origins allowed to access the APIs. Leave empty for '*' in dev
 CORS_ORIGINS=
+OPENAI_API_KEY=

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -14,6 +14,7 @@ import CreateFloorTrafficForm from "./components/CreateFloorTrafficForm";
 import Home                   from "./routes/Home";
 import Logo                   from "./components/Logo";
 import ReconPage              from "./pages/ReconPage";
+import ChatPage               from "./pages/ChatPage";
 
 export default function App() {
   // Track dark mode preference
@@ -75,6 +76,7 @@ export default function App() {
             ['/users', 'Users'],
             ['/inventory', 'Inventory'],
             ['/recon', 'Recon'],
+            ['/chat', 'AI Chat'],
             ['/activities', 'Activities'],
             ['/floor-traffic', "Today's Floor Log"],
             ['/floor-traffic/new', 'Log a Visitor'],
@@ -96,6 +98,7 @@ export default function App() {
           <Route path="/users" element={<UsersPage />} />
           <Route path="/inventory" element={<InventoryPage />} />
           <Route path="/recon" element={<ReconPage />} />
+          <Route path="/chat" element={<ChatPage />} />
           <Route path="/activities" element={<ActivityTimeline />} />
           <Route path="/floor-traffic" element={<FloorTrafficPage />} />
           <Route path="/floor-traffic/new" element={<CreateFloorTrafficForm />} />

--- a/frontend/src/pages/ChatPage.jsx
+++ b/frontend/src/pages/ChatPage.jsx
@@ -1,0 +1,54 @@
+import { useState } from 'react';
+
+export default function ChatPage() {
+  const API_BASE = `${import.meta.env.VITE_API_BASE_URL}/chat`;
+  const [input, setInput] = useState('');
+  const [messages, setMessages] = useState([]);
+
+  const sendMessage = async () => {
+    const text = input.trim();
+    if (!text) return;
+    setMessages(m => [...m, { role: 'user', content: text }]);
+    setInput('');
+    try {
+      const res = await fetch(API_BASE, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ message: text })
+      });
+      const data = await res.json();
+      if (data.answer) {
+        setMessages(m => [...m, { role: 'assistant', content: data.answer }]);
+      }
+    } catch (err) {
+      console.error(err);
+      setMessages(m => [...m, { role: 'assistant', content: 'Failed to get response' }]);
+    }
+  };
+
+  return (
+    <div className="max-w-2xl mx-auto space-y-4">
+      <h1 className="text-2xl font-bold">AI Chat</h1>
+      <div className="border rounded p-3 space-y-2 bg-white dark:bg-gray-900">
+        {messages.map((m, idx) => (
+          <div key={idx} className={m.role === 'user' ? 'text-right' : 'text-left'}>
+            <span className="whitespace-pre-wrap">{m.content}</span>
+          </div>
+        ))}
+      </div>
+      <div className="flex gap-2">
+        <input
+          type="text"
+          className="flex-1 border p-2 rounded dark:bg-gray-900 dark:border-gray-600"
+          value={input}
+          onChange={e => setInput(e.target.value)}
+          onKeyDown={e => e.key === 'Enter' && sendMessage()}
+          placeholder="Ask something..."
+        />
+        <button onClick={sendMessage} className="bg-electricblue text-white px-4 py-2 rounded">
+          Send
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -1,0 +1,19 @@
+from fastapi.testclient import TestClient
+from unittest.mock import AsyncMock, patch
+from types import SimpleNamespace
+from app.main import app
+
+client = TestClient(app)
+
+
+def test_chat_endpoint():
+    mock_resp = SimpleNamespace(choices=[SimpleNamespace(message=SimpleNamespace(content="hello"))])
+    with patch("app.routers.chat.openai.ChatCompletion.acreate", new=AsyncMock(return_value=mock_resp)), \
+         patch("app.routers.chat.openai.api_key", "test-key"):
+        response = client.post(
+            "/api/chat/",
+            content=b'{"message":"hi"}',
+            headers={"Content-Type": "application/json"},
+        )
+    assert response.status_code == 200
+    assert response.json() == {"answer": "hello"}


### PR DESCRIPTION
## Summary
- support ChatGPT-style queries with new `/api/chat` endpoint
- mount chat router in FastAPI
- document `OPENAI_API_KEY` env var
- add simple AI chat page in the React frontend
- expose page via navigation and routing
- test chat API endpoint

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686abafeb538832291d418e9ac50c948