### PR TITLE
Add global ChatGPT overlay

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -14,6 +14,7 @@ import CreateFloorTrafficForm from "./components/CreateFloorTrafficForm";
 import Home                   from "./routes/Home";
 import Logo                   from "./components/Logo";
 import ReconPage              from "./pages/ReconPage";
+import ChatGPTPrompt          from "./components/ChatGPTPrompt";
 
 export default function App() {
   // Track dark mode preference
@@ -83,6 +84,7 @@ export default function App() {
               {label}
             </Link>
           ))}
+          <ChatGPTPrompt />
         </div>
       </nav>
 

--- a/frontend/src/components/ChatGPTPrompt.jsx
+++ b/frontend/src/components/ChatGPTPrompt.jsx
@@ -1,0 +1,56 @@
+import { useState } from 'react';
+
+export default function ChatGPTPrompt() {
+  const [question, setQuestion] = useState('');
+  const [answer, setAnswer] = useState('');
+  const [open, setOpen] = useState(false);
+
+  const API_BASE = `${import.meta.env.VITE_API_BASE_URL}/leads`;
+
+  const askQuestion = async () => {
+    if (!question.trim()) return;
+    try {
+      const res = await fetch(`${API_BASE}/ask`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ question }),
+      });
+      const data = await res.json();
+      setAnswer(data.answer || 'No response');
+    } catch (err) {
+      console.error(err);
+      setAnswer('Failed to get response');
+    }
+    setOpen(true);
+  };
+
+  return (
+    <>
+      <div style={{ marginLeft: 'auto', display: 'flex', gap: '0.5rem' }}>
+        <input
+          type="text"
+          placeholder="Ask ChatGPT"
+          value={question}
+          onChange={(e) => setQuestion(e.target.value)}
+          style={{ padding: '0.25rem 0.5rem', border: '1px solid #ccc', borderRadius: '4px' }}
+        />
+        <button onClick={askQuestion} className="bg-electricblue text-white px-2 py-1 rounded">
+          Ask
+        </button>
+      </div>
+
+      {open && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+          <div className="bg-white dark:bg-gray-800 p-4 rounded shadow max-w-lg w-full">
+            <pre className="whitespace-pre-wrap">{answer}</pre>
+            <div className="text-right mt-4">
+              <button onClick={() => setOpen(false)} className="px-3 py-2 bg-electricblue text-white rounded">
+                Close
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/frontend/src/components/ChatGPTPrompt.jsx
+++ b/frontend/src/components/ChatGPTPrompt.jsx
@@ -41,8 +41,13 @@ export default function ChatGPTPrompt() {
       </div>
 
       {open && (
-        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
-          <div className="bg-white dark:bg-gray-800 p-4 rounded shadow max-w-lg w-full">
+        <div
+          className="fixed inset-0 bg-black/50 flex items-center justify-center z-50"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="modal-title"
+        >
+          <div className="bg-white dark:bg-gray-800 p-4 rounded shadow max-w-lg w-full" id="modal-title">
             <pre className="whitespace-pre-wrap">{answer}</pre>
             <div className="text-right mt-4">
               <button onClick={() => setOpen(false)} className="px-3 py-2 bg-electricblue text-white rounded">

--- a/frontend/src/components/ChatGPTPrompt.jsx
+++ b/frontend/src/components/ChatGPTPrompt.jsx
@@ -30,6 +30,7 @@ export default function ChatGPTPrompt() {
         <input
           type="text"
           placeholder="Ask ChatGPT"
+          aria-label="Ask a question to ChatGPT"
           value={question}
           onChange={(e) => setQuestion(e.target.value)}
           style={{ padding: '0.25rem 0.5rem', border: '1px solid #ccc', borderRadius: '4px' }}

--- a/frontend/src/components/ChatGPTPrompt.jsx
+++ b/frontend/src/components/ChatGPTPrompt.jsx
@@ -15,6 +15,9 @@ export default function ChatGPTPrompt() {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ question }),
       });
+      if (!res.ok) {
+        throw new Error(`Error: ${res.status} ${res.statusText}`);
+      }
       const data = await res.json();
       setAnswer(data.answer || 'No response');
     } catch (err) {


### PR DESCRIPTION
## Summary
- pin a ChatGPT prompt to the navigation bar
- show ChatGPT responses in an overlay

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686abb4024908322aa6885c490f037aa