### PR TITLE
Improve /leads/ask fallback

### DIFF
--- a/app/routers/leads.py
+++ b/app/routers/leads.py
@@ -142,6 +142,8 @@ async def ask_lead_question(payload: AskPayload):
     lead = next((l for l in leads if l["id"] == payload.lead_id), None)
     context = f"Lead info: {json.dumps(lead)}" if lead else ""
     prompt = f"{payload.question}\n{context}"
+    if not openai.api_key:
+        return {"answer": "OpenAI API key not configured"}
     try:
         chat = await openai.ChatCompletion.acreate(
             model="gpt-3.5-turbo",

--- a/tests/test_leads.py
+++ b/tests/test_leads.py
@@ -19,3 +19,23 @@ def test_list_leads():
 
     assert response.status_code == 200
     assert response.json() == sample
+
+
+def test_ask_no_openai_key():
+    payload = {"question": "Hi"}
+    exec_result = MagicMock(data=[], error=None)
+    mock_table = MagicMock()
+    mock_table.select.return_value.execute.return_value = exec_result
+    mock_supabase = MagicMock()
+    mock_supabase.table.return_value = mock_table
+
+    with patch("app.routers.leads.supabase", mock_supabase), \
+         patch("app.routers.leads.openai.api_key", None):
+        response = client.post(
+            "/api/leads/ask",
+            content=b'{"question": "Hi"}',
+            headers={"Content-Type": "application/json"},
+        )
+
+    assert response.status_code == 200
+    assert response.json() == {"answer": "OpenAI API key not configured"}


### PR DESCRIPTION
## Summary
- show a helpful message when the OpenAI API key isn't set
- cover the fallback behavior with tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ac4892db0832286d10dc4245945ba