### PR TITLE
Fix customer save from floor traffic

### DIFF
--- a/app/routers/floor_traffic.py
+++ b/app/routers/floor_traffic.py
@@ -99,8 +99,8 @@ async def create_floor_traffic(entry: FloorTrafficCustomerCreate):
                 "phone": created.get("phone"),
             }
         ).execute()
-    except APIError:
-        pass
+    except APIError as e:
+        logging.warning("Failed to insert contact record: %s", e)
 
     return created
 

--- a/app/routers/floor_traffic.py
+++ b/app/routers/floor_traffic.py
@@ -86,7 +86,23 @@ async def create_floor_traffic(entry: FloorTrafficCustomerCreate):
             detail="Database insertion failed, no data returned."
         )
 
-    return res.data[0]
+    created = res.data[0]
+
+    # Also create a contact record for the customer. Ignore errors so the
+    # floor-traffic entry is saved even if the contact already exists or the
+    # insert fails for some other reason.
+    try:
+        supabase.table("contacts").insert(
+            {
+                "name": created["customer_name"],
+                "email": created.get("email"),
+                "phone": created.get("phone"),
+            }
+        ).execute()
+    except APIError:
+        pass
+
+    return created
 
 
 @router.put("/{entry_id}", response_model=FloorTrafficCustomer)

--- a/tests/test_floor_traffic.py
+++ b/tests/test_floor_traffic.py
@@ -56,10 +56,24 @@ def test_create_floor_traffic():
     }
 
     exec_result = MagicMock(data=[sample], error=None)
-    mock_table = MagicMock()
-    mock_table.insert.return_value.execute.return_value = exec_result
+
+    mock_ft_table = MagicMock()
+    mock_ft_table.insert.return_value.execute.return_value = exec_result
+
+    mock_contacts_table = MagicMock()
+    mock_contacts_table.insert.return_value.execute.return_value = MagicMock(
+        data=[{"id": 99}], error=None
+    )
+
+    def table_side_effect(name):
+        if name == "floor_traffic_customers":
+            return mock_ft_table
+        elif name == "contacts":
+            return mock_contacts_table
+        return MagicMock()
+
     mock_supabase = MagicMock()
-    mock_supabase.table.return_value = mock_table
+    mock_supabase.table.side_effect = table_side_effect
 
     payload = {
         "timeIn": sample["visit_time"],
@@ -80,6 +94,7 @@ def test_create_floor_traffic():
 
     assert response.status_code == 201
     assert response.json() == sample
+    assert mock_contacts_table.insert.called
 
 
 def test_update_floor_traffic():


### PR DESCRIPTION
## Summary
- when a new floor traffic record is created also create a contact entry
- test that contact creation occurs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686ac869a9988322bed1a29ce20d9663