### PR TITLE
Fix OpenAI client usage in async endpoints

### DIFF
--- a/app/routers/chat.py
+++ b/app/routers/chat.py
@@ -3,7 +3,8 @@ from pydantic import BaseModel
 import os
 import openai
 
-openai.api_key = os.environ.get("OPENAI_API_KEY")
+api_key = os.environ.get("OPENAI_API_KEY")
+openai_client = openai.AsyncOpenAI(api_key=api_key) if api_key else None
 
 router = APIRouter()
 
@@ -12,10 +13,10 @@ class ChatRequest(BaseModel):
 
 @router.post("/")
 async def chat(req: ChatRequest):
-    if not openai.api_key:
+    if not openai_client:
         raise HTTPException(500, "OpenAI API key not configured")
     try:
-        resp = await openai.ChatCompletion.acreate(
+        resp = await openai_client.chat.completions.create(
             model="gpt-3.5-turbo",
             messages=[{"role": "user", "content": req.message}],
             temperature=0.3,

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -8,8 +8,12 @@ client = TestClient(app)
 
 def test_chat_endpoint():
     mock_resp = SimpleNamespace(choices=[SimpleNamespace(message=SimpleNamespace(content="hello"))])
-    with patch("app.routers.chat.openai.ChatCompletion.acreate", new=AsyncMock(return_value=mock_resp)), \
-         patch("app.routers.chat.openai.api_key", "test-key"):
+    mock_client = SimpleNamespace(
+        chat=SimpleNamespace(
+            completions=SimpleNamespace(create=AsyncMock(return_value=mock_resp))
+        )
+    )
+    with patch("app.routers.chat.openai_client", mock_client):
         response = client.post(
             "/api/chat/",
             content=b'{"message":"hi"}',

--- a/tests/test_leads.py
+++ b/tests/test_leads.py
@@ -30,7 +30,7 @@ def test_ask_no_openai_key():
     mock_supabase.table.return_value = mock_table
 
     with patch("app.routers.leads.supabase", mock_supabase), \
-         patch("app.routers.leads.openai.api_key", None):
+         patch("app.routers.leads.openai_client", None):
         response = client.post(
             "/api/leads/ask",
             content=b'{"question": "Hi"}',


### PR DESCRIPTION
## Summary
- migrate `openai` calls to v1 `AsyncOpenAI` client
- update tests for new client interface

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686acdf5ef408322ae520c15c9a03272