### PR TITLE
Fix ChatGPT API by loading key from Supabase

### DIFF
--- a/app/openai_client.py
+++ b/app/openai_client.py
@@ -1,0 +1,38 @@
+import os
+from typing import Optional
+from app.db import supabase
+import openai
+
+_openai_client: Optional[openai.AsyncOpenAI] = None
+
+
+def _load_key_from_supabase() -> Optional[str]:
+    """Fetch OPENAI_API_KEY from the Supabase 'settings' table."""
+    try:
+        res = (
+            supabase.table("settings")
+            .select("value")
+            .eq("key", "OPENAI_API_KEY")
+            .single()
+            .execute()
+        )
+        if res.data and isinstance(res.data, dict):
+            return res.data.get("value")
+    except Exception:
+        pass
+    return None
+
+
+def get_openai_client() -> Optional[openai.AsyncOpenAI]:
+    """Return a cached AsyncOpenAI client if configured."""
+    global _openai_client
+    if _openai_client:
+        return _openai_client
+
+    api_key = os.environ.get("OPENAI_API_KEY")
+    if not api_key:
+        api_key = _load_key_from_supabase()
+
+    if api_key:
+        _openai_client = openai.AsyncOpenAI(api_key=api_key)
+    return _openai_client

--- a/app/routers/chat.py
+++ b/app/routers/chat.py
@@ -1,10 +1,7 @@
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
-import os
-import openai
 
-api_key = os.environ.get("OPENAI_API_KEY")
-openai_client = openai.AsyncOpenAI(api_key=api_key) if api_key else None
+from app.openai_client import get_openai_client
 
 router = APIRouter()
 
@@ -13,10 +10,11 @@ class ChatRequest(BaseModel):
 
 @router.post("/")
 async def chat(req: ChatRequest):
-    if not openai_client:
+    client = get_openai_client()
+    if not client:
         raise HTTPException(500, "OpenAI API key not configured")
     try:
-        resp = await openai_client.chat.completions.create(
+        resp = await client.chat.completions.create(
             model="gpt-3.5-turbo",
             messages=[{"role": "user", "content": req.message}],
             temperature=0.3,

--- a/app/routers/leads.py
+++ b/app/routers/leads.py
@@ -3,13 +3,9 @@ from pydantic import BaseModel, EmailStr
 from typing import List, Optional
 from postgrest.exceptions import APIError
 from app.db import supabase
-import os
-import openai
+from app.openai_client import get_openai_client
 from datetime import datetime
 import json
-
-api_key = os.environ.get("OPENAI_API_KEY")
-openai_client = openai.AsyncOpenAI(api_key=api_key) if api_key else None
 
 router = APIRouter()
 
@@ -104,7 +100,8 @@ async def prioritized_leads():
     if not leads:
         return []
 
-    if not openai_client:
+    client = get_openai_client()
+    if not client:
         # simple heuristic fallback
         leads.sort(key=lambda l: l.get("last_lead_response_at") or "", reverse=True)
         return leads[:10]
@@ -115,7 +112,7 @@ async def prioritized_leads():
         f"Leads: {json.dumps(leads)}"
     )
     try:
-        chat = await openai_client.chat.completions.create(
+        chat = await client.chat.completions.create(
             model="gpt-3.5-turbo",
             messages=[{"role": "user", "content": prompt}],
             temperature=0,
@@ -143,10 +140,11 @@ async def ask_lead_question(payload: AskPayload):
     lead = next((l for l in leads if l["id"] == payload.lead_id), None)
     context = f"Lead info: {json.dumps(lead)}" if lead else ""
     prompt = f"{payload.question}\n{context}"
-    if not openai_client:
+    client = get_openai_client()
+    if not client:
         return {"answer": "OpenAI API key not configured"}
     try:
-        chat = await openai_client.chat.completions.create(
+        chat = await client.chat.completions.create(
             model="gpt-3.5-turbo",
             messages=[{"role": "user", "content": prompt}],
             temperature=0.3,

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -13,7 +13,7 @@ def test_chat_endpoint():
             completions=SimpleNamespace(create=AsyncMock(return_value=mock_resp))
         )
     )
-    with patch("app.routers.chat.openai_client", mock_client):
+    with patch("app.routers.chat.get_openai_client", return_value=mock_client):
         response = client.post(
             "/api/chat/",
             content=b'{"message":"hi"}',

--- a/tests/test_leads.py
+++ b/tests/test_leads.py
@@ -30,7 +30,7 @@ def test_ask_no_openai_key():
     mock_supabase.table.return_value = mock_table
 
     with patch("app.routers.leads.supabase", mock_supabase), \
-         patch("app.routers.leads.openai_client", None):
+         patch("app.routers.leads.get_openai_client", return_value=None):
         response = client.post(
             "/api/leads/ask",
             content=b'{"question": "Hi"}',


### PR DESCRIPTION
## Summary
- add helper to fetch the OpenAI key from Supabase
- use the helper in chat and leads routers
- update tests for new helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c6907553483228201ba5bae35111b