### PR TITLE
Expose inventory image links

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -189,6 +189,9 @@ class InventoryItem(CamelModel):
     fuel_type: Optional[str] = None
     drivetrain: Optional[str] = None
     active: Optional[bool] = True
+    image_link: Optional[str] = None
+    additional_image_link: Optional[str] = None
+    photos: Optional[list[str]] = None
     video_urls: Optional[list[str]] = None
     history_report: Optional[str] = None
 
@@ -206,6 +209,9 @@ class InventoryItemCreate(CamelModel):
     fuel_type: Optional[str] = None
     drivetrain: Optional[str] = None
     active: Optional[bool] = True
+    image_link: Optional[str] = None
+    additional_image_link: Optional[str] = None
+    photos: Optional[list[str]] = None
     video_urls: Optional[list[str]] = None
     history_report: Optional[str] = None
 
@@ -223,5 +229,8 @@ class InventoryItemUpdate(CamelModel):
     fuel_type: Optional[str] = None
     drivetrain: Optional[str] = None
     active: Optional[bool] = None
+    image_link: Optional[str] = None
+    additional_image_link: Optional[str] = None
+    photos: Optional[list[str]] = None
     video_urls: Optional[list[str]] = None
     history_report: Optional[str] = None


### PR DESCRIPTION
## Summary
- expose `image_link` and related fields from the inventory API

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686acec19a0083229dffca3fb55a96c6