### PR TITLE
Fix inventory card images

### DIFF
--- a/frontend/src/components/InventoryCard.jsx
+++ b/frontend/src/components/InventoryCard.jsx
@@ -9,8 +9,8 @@ export default function InventoryCard({ vehicle, onEdit, onToggle }) {
     images = vehicle.photos;
   } else {
     images = [
-      vehicle.image_link,
-      vehicle.additional_image_link,
+      vehicle.imageLink,
+      vehicle.additionalImageLink,
     ]
       .filter(Boolean)                  // drop null/undefined and empty strings
       .flatMap(link => link.split(',')) // split comma-separated lists


### PR DESCRIPTION
## Summary
- show vehicle images from `imageLink` and `additionalImageLink`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686c8dedc57883228fc4db41ab5b9282