### PR TITLE
Add basic Twilio telephony endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,11 @@ VITE_API_BASE_URL=http://localhost:8000
 VITE_SUPABASE_URL=<your-supabase-url>
 VITE_SUPABASE_KEY=<your-supabase-key>
 OPENAI_API_KEY=<your-openai-key>
+TWILIO_ACCOUNT_SID=<twilio-account-sid>
+TWILIO_API_KEY_SID=<twilio-api-key-sid>
+TWILIO_API_KEY_SECRET=<twilio-api-key-secret>
+TWIML_APP_SID=<twiml-app-sid>
+TWILIO_AUTH_TOKEN=<twilio-auth-token>
 ```
 
 Be sure to omit any trailing slashes from the origins.
@@ -49,6 +54,14 @@ Be sure to omit any trailing slashes from the origins.
 If `VITE_SUPABASE_URL` and `VITE_SUPABASE_KEY` are not provided, the
 floor-traffic page will automatically fall back to fetching data from the API
 server at `/api/floor-traffic`.
+
+## Telephony Integration
+
+With Twilio credentials configured, the backend exposes simple endpoints for
+voice and SMS callbacks. Use `/api/telephony/token` to obtain a WebRTC token for
+your browser client. Configure your Twilio number webhooks to point at
+`/api/telephony/voice` for calls and `/api/telephony/sms` for incoming text
+messages.
 
 ## Using the Supabase API
 

--- a/app/main.py
+++ b/app/main.py
@@ -13,6 +13,7 @@ from app.routers.opportunities   import router as opportunities_router
 from app.routers.activities      import router as activities_router
 from app.routers import inventory  # inventory router mounted under /api/inventory
 from app.routers.chat            import router as chat_router
+from app.routers.telephony       import router as telephony_router
 
 app = FastAPI(title="aiVenta CRM API")
 
@@ -64,6 +65,7 @@ app.include_router(
     tags=["inventory"],
 )
 app.include_router(chat_router, prefix="/api/chat", tags=["chat"])
+app.include_router(telephony_router, prefix="/api/telephony", tags=["telephony"])
 
 # 4️⃣ Serve your React app for all other GETs
 app.mount(

--- a/app/routers/__init__.py
+++ b/app/routers/__init__.py
@@ -1,1 +1,2 @@
 from pydantic import BaseModel
+

--- a/app/routers/telephony.py
+++ b/app/routers/telephony.py
@@ -1,0 +1,42 @@
+from fastapi import APIRouter, HTTPException, Request, Response
+from twilio.jwt.access_token import AccessToken
+from twilio.jwt.access_token.grants import VoiceGrant
+from twilio.request_validator import RequestValidator
+import os
+import logging
+
+router = APIRouter()
+
+TWILIO_ACCOUNT_SID = os.getenv("TWILIO_ACCOUNT_SID")
+TWILIO_API_KEY_SID = os.getenv("TWILIO_API_KEY_SID")
+TWILIO_API_KEY_SECRET = os.getenv("TWILIO_API_KEY_SECRET")
+TWIML_APP_SID = os.getenv("TWIML_APP_SID")
+TWILIO_AUTH_TOKEN = os.getenv("TWILIO_AUTH_TOKEN")
+
+validator = RequestValidator(TWILIO_AUTH_TOKEN) if TWILIO_AUTH_TOKEN else None
+logger = logging.getLogger(__name__)
+
+@router.get("/token")
+def generate_token(identity: str):
+    if not (TWILIO_ACCOUNT_SID and TWILIO_API_KEY_SID and TWILIO_API_KEY_SECRET and TWIML_APP_SID):
+        raise HTTPException(500, "Twilio env vars not configured")
+    token = AccessToken(TWILIO_ACCOUNT_SID, TWILIO_API_KEY_SID, TWILIO_API_KEY_SECRET, identity=identity)
+    voice_grant = VoiceGrant(outgoing_application_sid=TWIML_APP_SID, incoming_allow=True)
+    token.add_grant(voice_grant)
+    return {"token": token.to_jwt().decode()}
+
+@router.post("/voice")
+async def inbound_call(request: Request):
+    if validator and not validator.validate(str(request.url), await request.body(), request.headers.get("X-Twilio-Signature", "")):
+        raise HTTPException(status_code=403, detail="Invalid signature")
+    data = await request.form()
+    logger.info(f"Inbound call from {data.get('From')} to {data.get('To')}")
+    return Response("<Response><Say>Call received</Say></Response>", media_type="text/xml")
+
+@router.post("/sms")
+async def inbound_sms(request: Request):
+    if validator and not validator.validate(str(request.url), await request.body(), request.headers.get("X-Twilio-Signature", "")):
+        raise HTTPException(status_code=403, detail="Invalid signature")
+    data = await request.form()
+    logger.info(f"SMS from {data.get('From')}: {data.get('Body')}")
+    return Response("<Response></Response>", media_type="text/xml")

--- a/env.example
+++ b/env.example
@@ -3,3 +3,8 @@ SUPABASE_KEY=<your-supabase-key>
 # Comma separated list of origins allowed to access the APIs. Leave empty for '*' in dev
 CORS_ORIGINS=
 OPENAI_API_KEY=
+TWILIO_ACCOUNT_SID=
+TWILIO_API_KEY_SID=
+TWILIO_API_KEY_SECRET=
+TWIML_APP_SID=
+TWILIO_AUTH_TOKEN=

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ supabase
 email-validator>=1.3.0
 openai
 httpx<0.28
+twilio


### PR DESCRIPTION
## Summary
- add placeholders for Twilio credentials in `env.example`
- document telephony environment variables and endpoints in README
- add `twilio` dependency
- create `telephony` router with token, voice, and sms handlers
- register telephony routes in FastAPI app

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c9b3a18648322bfeadfa34477cf2c