### PR TITLE
Fix time out persistence in floor log

### DIFF
--- a/frontend/src/pages/FloorTrafficPage.jsx
+++ b/frontend/src/pages/FloorTrafficPage.jsx
@@ -130,6 +130,7 @@ export default function FloorTrafficPage() {
           method: 'PUT',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(payload),
+          keepalive: true,
         });
       }
     } catch (err) {
@@ -151,6 +152,7 @@ export default function FloorTrafficPage() {
           method: 'PUT',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(data),
+          keepalive: true,
         });
       }
       setRows(prev => prev.map(r => (r.id === editing.id ? { ...r, ...data } : r)));


### PR DESCRIPTION
## Summary
- ensure `fetch` requests remain alive when navigating away from the floor traffic page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d4c0d4da883229e97307385ec2dc7