### PR TITLE
Fix activities column name

### DIFF
--- a/frontend/src/pages/FloorTrafficPage.jsx
+++ b/frontend/src/pages/FloorTrafficPage.jsx
@@ -74,13 +74,13 @@ export default function FloorTrafficPage() {
           end.setDate(end.getDate() + 1);
           const { data, error: err } = await supabase
             .from('activities')
-            .select('activities_type')
+            .select('activity_type')
             .gte('created_at', start.toISOString())
             .lt('created_at', end.toISOString());
           if (err) throw err;
           const counts = { salesCalls: 0, textMessages: 0, appointmentsSet: 0 };
           for (const row of data || []) {
-            const t = String(row.type || '').toLowerCase();
+            const t = String(row.activity_type || '').toLowerCase();
             if (t.includes('call')) counts.salesCalls++;
             else if (t.includes('text')) counts.textMessages++;
             else if (t.includes('appointment')) counts.appointmentsSet++;


### PR DESCRIPTION
## Summary
- query `activity_type` column instead of `activities_type`
- update code that parses the activity type

## Testing
- `npm test` *(fails: Missing script)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d4e4529a08322b1225447bfe023f1