### PR TITLE
Fix offer label

### DIFF
--- a/frontend/src/components/FloorTrafficTable.jsx
+++ b/frontend/src/components/FloorTrafficTable.jsx
@@ -33,7 +33,7 @@ export default function FloorTrafficTable({ rows, onEdit, onToggle }) {
     { key: 'vehicle', label: 'Vehicle' },
     { key: 'demo', label: 'Demo' },
     { key: 'worksheet', label: 'Worksheet' },
-    { key: 'customer_offer', label: 'Customer Offer' },
+    { key: 'customer_offer', label: 'Offer' },
     { key: 'sold', label: 'Sold' },
     { key: 'notes', label: 'Notes' },
     { key: 'phone', label: 'Phone' }


### PR DESCRIPTION
## Summary
- change the Floor Log header from `Customer Offer` to `Offer`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686dcf1ce3c08322a9ede577c133c782