### PR TITLE
Add customers API and update frontend

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -9,6 +9,7 @@ from app.routers.users           import router as users_router
 from app.routers import floor_traffic
 from app.routers.accounts        import router as accounts_router
 from app.routers.contacts        import router as contacts_router
+from app.routers.customers       import router as customers_router
 from app.routers.opportunities   import router as opportunities_router
 from app.routers.activities      import router as activities_router
 from app.routers import inventory  # inventory router mounted under /api/inventory
@@ -74,6 +75,7 @@ app.include_router(
 )
 app.include_router(accounts_router,      prefix="/api/accounts",      tags=["accounts"])
 app.include_router(contacts_router,      prefix="/api/contacts",      tags=["contacts"])
+app.include_router(customers_router,     prefix="/api/customers",     tags=["customers"])
 app.include_router(opportunities_router, prefix="/api/opportunities", tags=["opportunities"])
 app.include_router(activities_router,    prefix="/api/activities",    tags=["activities"])
 # now include your inventory router

--- a/app/models.py
+++ b/app/models.py
@@ -39,6 +39,27 @@ class ContactUpdate(BaseModel):
     phone: Optional[str]
 
 
+# ── Customers ─────────────────────────────────────────────────────────────────
+
+class Customer(BaseModel):
+    id: str
+    name: str
+    email: Optional[str]
+    phone: Optional[str]
+
+
+class CustomerCreate(BaseModel):
+    name: str
+    email: Optional[str]
+    phone: Optional[str]
+
+
+class CustomerUpdate(BaseModel):
+    name: Optional[str]
+    email: Optional[str]
+    phone: Optional[str]
+
+
 # ── Accounts ───────────────────────────────────────────────────────────────────
 
 class Account(BaseModel):

--- a/app/routers/customers.py
+++ b/app/routers/customers.py
@@ -1,0 +1,85 @@
+from fastapi import APIRouter, HTTPException, status, Query
+from postgrest.exceptions import APIError
+from app.db import supabase
+from app.models import Customer, CustomerCreate, CustomerUpdate
+
+router = APIRouter()
+
+@router.get("/", response_model=list[Customer])
+def list_customers(
+    q: str | None = Query(None, description="Search term for name"),
+    email: str | None = Query(None, description="Filter by email"),
+    phone: str | None = Query(None, description="Filter by phone"),
+):
+    """List customers with optional search filters."""
+    query = supabase.table("customers").select("*")
+    if q:
+        query = query.ilike("name", f"%{q}%")
+    if email:
+        query = query.ilike("email", f"%{email}%")
+    if phone:
+        query = query.ilike("phone", f"%{phone}%")
+
+    res = query.execute()
+    return res.data
+
+
+@router.get("/{customer_id}", response_model=Customer)
+def get_customer(customer_id: int):
+    res = (
+        supabase
+        .table("customers")
+        .select("*")
+        .eq("id", customer_id)
+        .maybe_single()
+        .execute()
+    )
+    if not res.data:
+        raise HTTPException(status_code=404, detail="Customer not found")
+    return res.data
+
+
+@router.post("/", response_model=Customer, status_code=status.HTTP_201_CREATED)
+def create_customer(c: CustomerCreate):
+    try:
+        res = supabase.table("customers").insert(c.dict()).execute()
+    except APIError as e:
+        raise HTTPException(status_code=400, detail=e.message)
+    return res.data[0]
+
+
+@router.patch("/{customer_id}", response_model=Customer)
+def update_customer(customer_id: int, c: CustomerUpdate):
+    payload = {k: v for k, v in c.dict().items() if v is not None}
+    if not payload:
+        raise HTTPException(status_code=400, detail="No fields to update")
+    try:
+        res = (
+            supabase
+            .table("customers")
+            .update(payload)
+            .eq("id", customer_id)
+            .execute()
+        )
+    except APIError as e:
+        raise HTTPException(status_code=400, detail=e.message)
+    if not res.data:
+        raise HTTPException(status_code=404, detail="Customer not found")
+    return res.data[0]
+
+
+@router.delete("/{customer_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_customer(customer_id: int):
+    try:
+        res = (
+            supabase
+            .table("customers")
+            .delete()
+            .eq("id", customer_id)
+            .execute()
+        )
+    except APIError as e:
+        raise HTTPException(status_code=400, detail=e.message)
+    if not res.data:
+        raise HTTPException(status_code=404, detail="Customer not found")
+    return

--- a/frontend/src/routes/CustomerCard.jsx
+++ b/frontend/src/routes/CustomerCard.jsx
@@ -12,7 +12,7 @@ export default function CustomerCard() {
   useEffect(() => {
     const fetchCustomer = async () => {
       try {
-        const res = await fetch(`${API_BASE}/contacts/${id}`);
+        const res = await fetch(`${API_BASE}/customers/${id}`);
         if (!res.ok) throw new Error('Failed to load customer');
         const data = await res.json();
         setCustomer(data);

--- a/frontend/src/routes/CustomersPage.jsx
+++ b/frontend/src/routes/CustomersPage.jsx
@@ -21,7 +21,7 @@ export default function CustomersPage() {
       try {
         const params = new URLSearchParams()
         if (debounced) params.append('q', debounced)
-        const res = await fetch(`${API_BASE}/contacts/?${params.toString()}`)
+        const res = await fetch(`${API_BASE}/customers/?${params.toString()}`)
         if (!res.ok) throw new Error('Failed to load customers')
         const data = await res.json()
         setCustomers(Array.isArray(data) ? data : [])

--- a/tests/test_customers.py
+++ b/tests/test_customers.py
@@ -1,0 +1,55 @@
+from fastapi.testclient import TestClient
+from unittest.mock import MagicMock, patch
+from app.main import app
+client = TestClient(app)
+
+
+def test_search_customers():
+    sample = [{
+        "id": "1",
+        "name": "Alice",
+        "email": "a@example.com",
+        "phone": "123",
+    }]
+    exec_result = MagicMock(data=sample, error=None)
+
+    mock_query = MagicMock()
+    mock_query.ilike.return_value = mock_query
+    mock_query.execute.return_value = exec_result
+
+    mock_table = MagicMock()
+    mock_table.select.return_value = mock_query
+    mock_supabase = MagicMock()
+    mock_supabase.table.return_value = mock_table
+
+    with patch("app.routers.customers.supabase", mock_supabase):
+        response = client.get("/api/customers/?q=Ali")
+
+    assert response.status_code == 200
+    assert response.json() == sample
+    mock_query.ilike.assert_any_call("name", "%Ali%")
+
+
+def test_get_customer():
+    sample = {
+        "id": "1",
+        "name": "Alice",
+        "email": "a@example.com",
+        "phone": "123",
+    }
+    exec_result = MagicMock(data=sample, error=None)
+
+    mock_select = MagicMock()
+    mock_select.eq.return_value.maybe_single.return_value.execute.return_value = exec_result
+
+    mock_table = MagicMock()
+    mock_table.select.return_value = mock_select
+    mock_supabase = MagicMock()
+    mock_supabase.table.return_value = mock_table
+
+    with patch("app.routers.customers.supabase", mock_supabase):
+        response = client.get("/api/customers/1")
+
+    assert response.status_code == 200
+    assert response.json() == sample
+    mock_select.eq.assert_called_with("id", 1)


### PR DESCRIPTION
## Summary
- add `Customer` models and routers backed by Supabase `customers` table
- expose `/api/customers` endpoints in FastAPI
- update customers pages to use new endpoints
- include tests for customers endpoints

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f0cc30bc88322a964a275e84fc0d6