### PR TITLE
Remove hero area from home page

### DIFF
--- a/frontend/src/routes/Home.jsx
+++ b/frontend/src/routes/Home.jsx
@@ -1,31 +1,10 @@
 import React from 'react';
-import Logo from '../components/Logo';
 import SalesPerformanceKPI from '../components/SalesPerformanceKPI';
 
 export default function Home() {
   return (
-    <div>
-      <section className="relative w-full min-h-screen overflow-hidden flex items-center justify-center text-offwhite text-center px-4 bg-darkblue">
-        <div className="absolute inset-0 bg-gradient-to-tr from-purple-700 via-electricblue to-neongreen opacity-60 animate-gradient" />
-        <div className="relative z-10">
-          <h1 className="text-5xl sm:text-7xl font-extrabold tracking-tight mb-6 drop-shadow-2xl">
-            <span className="sr-only">aiVenta CRM</span>
-            <Logo className="mx-auto" />
-          </h1>
-          <p className="text-xl sm:text-3xl mb-8 max-w-3xl font-medium">
-            Manage leads, users and floor traffic with next‑gen efficiency.
-          </p>
-          <a
-            href="/leads"
-            className="sheen-link inline-block px-8 py-4 text-lg font-semibold text-darkblue bg-neongreen rounded-md shadow-xl hover:bg-offwhite hover:text-darkblue transition-colors"
-          >
-            Get Started
-          </a>
-        </div>
-      </section>
-      <div className="max-w-4xl mx-auto p-6 -mt-16">
-        <SalesPerformanceKPI />
-      </div>
+    <div className="max-w-4xl mx-auto p-6">
+      <SalesPerformanceKPI />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- simplify the `Home` route
- remove logo, hero text and link from homepage

## Testing
- `npm run lint`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686f0d9db85c8322a5790a72722dfe1f