### PR TITLE
Fix navigation color

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -60,6 +60,7 @@ export default function App() {
     top: 0,
     left: 0,
     right: 0,
+    backgroundColor: "#1C64F2",
     zIndex: 1000,
   };
   const navInnerStyle = {
@@ -105,7 +106,7 @@ export default function App() {
       <Toaster position="top-right" />
 
       {/* FIXED TOP NAV */}
-      <nav ref={navRef} style={navStyle} className={`animate-logoCycle transition-colors duration-1000 ${lightText ? 'text-white' : 'text-black'}`}>
+      <nav ref={navRef} style={navStyle} className={`transition-colors duration-1000 ${lightText ? 'text-white' : 'text-black'}`}>
         <div style={navInnerStyle}>
           <Link to="/" style={{ marginRight: "1rem" }}>
             <Logo />

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -60,7 +60,7 @@ export default function App() {
     top: 0,
     left: 0,
     right: 0,
-    backgroundColor: "#1C64F2",
+    backgroundColor: "rgb(var(--current-bg-rgb))",
     zIndex: 1000,
   };
   const navInnerStyle = {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -7,7 +7,7 @@
   line-height: 1.5;
   font-weight: 400;
 
-  --current-bg-rgb: 250,166,26;
+  --current-bg-rgb: 28,100,242;
 
   color-scheme: light;
   color: #213547;


### PR DESCRIPTION
## Summary
- set nav background color to the original home page blue
- remove color cycling animation from navigation
- update default --current-bg-rgb value

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f20b776a08322b28f04dc541e9a02