### PR TITLE
Implement dashboard sections with metrics and AI summary

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -15,6 +15,7 @@ from app.routers.activities      import router as activities_router
 from app.routers import inventory  # inventory router mounted under /api/inventory
 from app.routers.chat            import router as chat_router
 from app.routers.telephony       import router as telephony_router
+from app.routers.analytics       import router as analytics_router
 
 app = FastAPI(title="aiVenta CRM API")
 
@@ -87,6 +88,7 @@ app.include_router(
     prefix="/api/inventory",
     tags=["inventory"],
 )
+app.include_router(analytics_router, prefix="/api/analytics", tags=["analytics"])
 app.include_router(chat_router, prefix="/api/chat", tags=["chat"])
 app.include_router(telephony_router, prefix="/api/telephony", tags=["telephony"])
 

--- a/app/routers/analytics.py
+++ b/app/routers/analytics.py
@@ -1,0 +1,32 @@
+from fastapi import APIRouter, HTTPException
+
+from app.routers import floor_traffic, leads
+from app.openai_client import get_openai_client
+
+router = APIRouter()
+
+@router.get("/month-summary")
+async def month_summary():
+    """Return an AI generated summary for the current month."""
+    ft_metrics = floor_traffic.month_metrics()
+    lead_metrics = leads.month_metrics()
+
+    client = get_openai_client()
+    if not client:
+        return {"summary": "OpenAI API key not configured"}
+
+    prompt = (
+        "Provide a concise summary of this month's performance given these metrics. "
+        f"Floor traffic: {ft_metrics}. Lead metrics: {lead_metrics}."
+    )
+
+    try:
+        chat = await client.chat.completions.create(
+            model="gpt-3.5-turbo",
+            messages=[{"role": "user", "content": prompt}],
+            temperature=0.3,
+        )
+        return {"summary": chat.choices[0].message.content}
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+

--- a/app/routers/inventory.py
+++ b/app/routers/inventory.py
@@ -55,6 +55,21 @@ def list_inventory(
 def list_inventory_noslash():
     return list_inventory()
 
+
+@router.get("/snapshot")
+def inventory_snapshot():
+    """Return basic counts of active and inactive inventory."""
+    try:
+        res = supabase.table("inventory").select("active").execute()
+    except APIError as e:
+        raise HTTPException(status_code=500, detail=e.message)
+
+    rows = res.data or []
+    total = len(rows)
+    active_count = sum(1 for r in rows if r.get("active"))
+    inactive_count = total - active_count
+    return {"total": total, "active": active_count, "inactive": inactive_count}
+
 @router.get("/{item_id}", response_model=InventoryItem)
 def get_inventory_item(item_id: int):
     res = (

--- a/frontend/src/components/InventorySnapshot.jsx
+++ b/frontend/src/components/InventorySnapshot.jsx
@@ -1,0 +1,37 @@
+import React, { useEffect, useState } from 'react';
+
+export default function InventorySnapshot() {
+  const [stats, setStats] = useState({ total: 0, active: 0, inactive: 0 });
+
+  useEffect(() => {
+    const API_BASE = import.meta.env.PROD ? import.meta.env.VITE_API_BASE_URL : '/api';
+    const fetchStats = async () => {
+      try {
+        const res = await fetch(`${API_BASE}/inventory/snapshot`);
+        if (!res.ok) return;
+        const data = await res.json();
+        setStats({
+          total: data.total ?? 0,
+          active: data.active ?? 0,
+          inactive: data.inactive ?? 0,
+        });
+      } catch (err) {
+        console.error(err);
+      }
+    };
+    fetchStats();
+  }, []);
+
+  const kpiClass = 'rounded-3xl p-6 bg-gradient-to-br from-electricblue via-darkblue to-slategray text-white shadow-lg';
+
+  return (
+    <div className={kpiClass}>
+      <h2 className="text-lg font-semibold mb-2">Inventory Snapshot</h2>
+      <ul className="space-y-1 text-sm">
+        <li>Total Vehicles: {stats.total}</li>
+        <li>Active: {stats.active}</li>
+        <li>Inactive: {stats.inactive}</li>
+      </ul>
+    </div>
+  );
+}

--- a/frontend/src/components/LeadPerformanceKPI.jsx
+++ b/frontend/src/components/LeadPerformanceKPI.jsx
@@ -1,0 +1,50 @@
+import React, { useEffect, useState } from 'react';
+
+export default function LeadPerformanceKPI() {
+  const [stats, setStats] = useState({
+    total: 0,
+    engagement: 0,
+    conversion: 0,
+    avgResponse: 0,
+  });
+
+  useEffect(() => {
+    const API_BASE = import.meta.env.PROD ? import.meta.env.VITE_API_BASE_URL : '/api';
+    const fetchStats = async () => {
+      try {
+        const res = await fetch(`${API_BASE}/leads/month-metrics`);
+        if (!res.ok) return;
+        const data = await res.json();
+        setStats({
+          total: data.total_leads ?? data.totalLeads ?? 0,
+          engagement: data.lead_engagement_rate ?? data.leadEngagementRate ?? 0,
+          conversion: data.conversion_rate ?? data.conversionRate ?? 0,
+          avgResponse: data.average_response_time ?? data.averageResponseTime ?? 0,
+        });
+      } catch (err) {
+        console.error(err);
+      }
+    };
+    fetchStats();
+  }, []);
+
+  const kpiClass = 'rounded-3xl p-6 bg-gradient-to-br from-electricblue via-darkblue to-slategray text-white shadow-lg';
+
+  const formatTime = secs => {
+    if (!secs) return '0m';
+    const mins = Math.round(secs / 60);
+    return `${mins}m`;
+  };
+
+  return (
+    <div className={kpiClass}>
+      <h2 className="text-lg font-semibold mb-2">MTD Lead Performance</h2>
+      <ul className="space-y-1 text-sm">
+        <li>Total Leads: {stats.total}</li>
+        <li>Engagement Rate: {stats.engagement}%</li>
+        <li>Conversion Rate: {stats.conversion}%</li>
+        <li>Avg Response: {formatTime(stats.avgResponse)}</li>
+      </ul>
+    </div>
+  );
+}

--- a/frontend/src/components/MonthlySummary.jsx
+++ b/frontend/src/components/MonthlySummary.jsx
@@ -1,0 +1,29 @@
+import React, { useEffect, useState } from 'react';
+
+export default function MonthlySummary() {
+  const [summary, setSummary] = useState('');
+
+  useEffect(() => {
+    const API_BASE = import.meta.env.PROD ? import.meta.env.VITE_API_BASE_URL : '/api';
+    const fetchSummary = async () => {
+      try {
+        const res = await fetch(`${API_BASE}/analytics/month-summary`);
+        if (!res.ok) return;
+        const data = await res.json();
+        setSummary(data.summary || '');
+      } catch (err) {
+        console.error(err);
+      }
+    };
+    fetchSummary();
+  }, []);
+
+  const kpiClass = 'rounded-3xl p-6 bg-gradient-to-br from-electricblue via-darkblue to-slategray text-white shadow-lg';
+
+  return (
+    <div className={kpiClass}>
+      <h2 className="text-lg font-semibold mb-2">AI Monthly Summary</h2>
+      <p className="text-sm whitespace-pre-wrap">{summary}</p>
+    </div>
+  );
+}

--- a/frontend/src/routes/Home.jsx
+++ b/frontend/src/routes/Home.jsx
@@ -1,10 +1,16 @@
 import React from 'react';
 import SalesPerformanceKPI from '../components/SalesPerformanceKPI';
+import LeadPerformanceKPI from '../components/LeadPerformanceKPI';
+import InventorySnapshot from '../components/InventorySnapshot';
+import MonthlySummary from '../components/MonthlySummary';
 
 export default function Home() {
   return (
-    <div className="max-w-4xl mx-auto p-6">
+    <div className="max-w-6xl mx-auto p-6 grid gap-4 md:grid-cols-2">
       <SalesPerformanceKPI />
+      <LeadPerformanceKPI />
+      <InventorySnapshot />
+      <MonthlySummary />
     </div>
   );
 }

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -1,0 +1,18 @@
+from fastapi.testclient import TestClient
+from types import SimpleNamespace
+from unittest.mock import patch
+from app.main import app
+
+client = TestClient(app)
+
+
+def test_month_summary_no_openai():
+    ft_metrics = {"total_customers": 5}
+    lead_metrics = {"total_leads": 2}
+    with patch("app.routers.analytics.floor_traffic.month_metrics", return_value=ft_metrics), \
+         patch("app.routers.analytics.leads.month_metrics", return_value=lead_metrics), \
+         patch("app.routers.analytics.get_openai_client", return_value=None):
+        response = client.get("/api/analytics/month-summary")
+
+    assert response.status_code == 200
+    assert response.json() == {"summary": "OpenAI API key not configured"}

--- a/tests/test_inventory.py
+++ b/tests/test_inventory.py
@@ -66,3 +66,17 @@ def test_filter_inventory_query_params():
     assert data[0]["make"] == "Ford"
     mock_query.ilike.assert_called_with("make", "%Ford%")
     mock_query.gte.assert_called_with("year", 2020)
+
+def test_inventory_snapshot():
+    sample = [{"active": True}, {"active": False}]
+    exec_result = MagicMock(data=sample, error=None)
+    mock_table = MagicMock()
+    mock_table.select.return_value.execute.return_value = exec_result
+    mock_supabase = MagicMock()
+    mock_supabase.table.return_value = mock_table
+
+    with patch("app.routers.inventory.supabase", mock_supabase):
+        response = client.get("/api/inventory/snapshot")
+
+    assert response.status_code == 200
+    assert response.json() == {"total": 2, "active": 1, "inactive": 1}

--- a/tests/test_leads.py
+++ b/tests/test_leads.py
@@ -39,3 +39,35 @@ def test_ask_no_openai_key():
 
     assert response.status_code == 200
     assert response.json() == {"answer": "OpenAI API key not configured"}
+
+def test_month_metrics():
+    sample = [
+        {
+            "created_at": "2024-01-01T00:00:00",
+            "last_lead_response_at": "2024-01-01T00:10:00",
+            "last_staff_response_at": "2024-01-01T00:20:00",
+        },
+        {
+            "created_at": "2024-01-02T00:00:00",
+            "last_lead_response_at": None,
+            "last_staff_response_at": None,
+        },
+    ]
+    exec_result = MagicMock(data=sample, error=None)
+    mock_table = MagicMock()
+    (
+        mock_table.select.return_value.gte.return_value.lt.return_value.execute.return_value
+    ) = exec_result
+    mock_supabase = MagicMock()
+    mock_supabase.table.return_value = mock_table
+
+    with patch("app.routers.leads.supabase", mock_supabase):
+        response = client.get("/api/leads/month-metrics")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "total_leads": 2,
+        "conversion_rate": 50.0,
+        "average_response_time": 600.0,
+        "lead_engagement_rate": 50.0,
+    }


### PR DESCRIPTION
## Summary
- add backend endpoints for inventory snapshot, MTD lead metrics and AI month summary
- expose analytics router in API
- create React widgets for lead performance, inventory snapshot and monthly AI summary
- show all four widgets on the Home page
- cover new functionality with tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f23e744548322b2659e335854d8fd