### PR TITLE
Add expanded KPI grid on CRM homepage

### DIFF
--- a/frontend/src/components/CustomerSatisfaction.jsx
+++ b/frontend/src/components/CustomerSatisfaction.jsx
@@ -1,0 +1,88 @@
+import React, { useEffect, useState } from 'react';
+import { Smile, Heart, X } from 'lucide-react';
+import { ResponsiveContainer, BarChart, Bar, Tooltip } from 'recharts';
+
+export default function CustomerSatisfaction() {
+  const [stats, setStats] = useState({
+    csi: 0,
+    retention: 0,
+    nps: 0,
+    retentionSeries: [],
+    npsSeries: [],
+  });
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    const API_BASE = import.meta.env.PROD ? import.meta.env.VITE_API_BASE_URL : '/api';
+    const fetchStats = async () => {
+      try {
+        const res = await fetch(`${API_BASE}/analytics/customer-satisfaction`);
+        if (!res.ok) return;
+        const data = await res.json();
+        setStats({
+          csi: data.csi ?? 0,
+          retention: data.retention ?? 0,
+          nps: data.nps ?? 0,
+          retentionSeries: Array.isArray(data.retentionSeries) ? data.retentionSeries : [],
+          npsSeries: Array.isArray(data.npsSeries) ? data.npsSeries : [],
+        });
+      } catch (err) {
+        console.error(err);
+      }
+    };
+    fetchStats();
+  }, []);
+
+  const csiColor = stats.csi >= 8 ? 'text-green-600' : stats.csi >= 6 ? 'text-orange-500' : 'text-red-600';
+
+  return (
+    <>
+      <div className="bg-white p-4 rounded-lg shadow space-y-3">
+        <div className="flex items-center gap-1">
+          <Smile className="w-4 h-4" />
+          <Heart className="w-4 h-4" />
+          <h3 className="font-semibold">Customer Satisfaction & Retention</h3>
+        </div>
+        <div className={`text-2xl font-bold ${csiColor}`}>{stats.csi.toFixed(1)}</div>
+        <div className="space-y-2 text-xs">
+          <div>Retention Rate {stats.retention}%</div>
+          <div className="h-3">
+            <ResponsiveContainer width="100%" height="100%">
+              <BarChart data={[{ name: 'ret', value: stats.retention }]}>\
+                <Tooltip />
+                <Bar dataKey="value" fill="#3b82f6" />
+              </BarChart>
+            </ResponsiveContainer>
+          </div>
+          <div>NPS {stats.nps}</div>
+          <div className="h-3">
+            <ResponsiveContainer width="100%" height="100%">
+              <BarChart data={[{ name: 'nps', value: stats.nps }]}>\
+                <Tooltip />
+                <Bar dataKey="value" fill="#10b981" />
+              </BarChart>
+            </ResponsiveContainer>
+          </div>
+        </div>
+        <button onClick={() => setOpen(true)} className="text-blue-600 text-xs underline">
+          View Details
+        </button>
+      </div>
+      {open && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50" role="dialog" aria-modal="true">
+          <div className="bg-white p-4 rounded shadow max-w-md w-full relative">
+            <button className="absolute top-2 right-2" onClick={() => setOpen(false)}>
+              <X className="w-4 h-4" />
+            </button>
+            <pre className="whitespace-pre-wrap text-xs">{JSON.stringify(stats, null, 2)}</pre>
+            <div className="text-right mt-4">
+              <button onClick={() => setOpen(false)} className="px-3 py-1 bg-electricblue text-white rounded">
+                Close
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/frontend/src/components/MarketingCampaignROI.jsx
+++ b/frontend/src/components/MarketingCampaignROI.jsx
@@ -1,0 +1,63 @@
+import React, { useEffect, useState } from 'react';
+import { Megaphone } from 'lucide-react';
+import { ResponsiveContainer, BarChart, Bar, Tooltip } from 'recharts';
+
+export default function MarketingCampaignROI() {
+  const [stats, setStats] = useState({
+    spend: 0,
+    revenue: 0,
+    cpl: 0,
+    roi: 0,
+    conversionByChannel: [],
+  });
+
+  useEffect(() => {
+    const API_BASE = import.meta.env.PROD ? import.meta.env.VITE_API_BASE_URL : '/api';
+    const fetchStats = async () => {
+      try {
+        const res = await fetch(`${API_BASE}/analytics/marketing-roi`);
+        if (!res.ok) return;
+        const data = await res.json();
+        setStats({
+          spend: data.spend ?? 0,
+          revenue: data.revenue ?? 0,
+          cpl: data.cpl ?? 0,
+          roi: data.roi ?? 0,
+          conversionByChannel: Array.isArray(data.conversionByChannel) ? data.conversionByChannel : [],
+        });
+      } catch (err) {
+        console.error(err);
+      }
+    };
+    fetchStats();
+  }, []);
+
+  const pct = stats.spend && stats.revenue ? Math.min((stats.revenue / stats.spend) * 100, 100) : 0;
+
+  return (
+    <div className="bg-white p-4 rounded-lg shadow space-y-3">
+      <div className="flex items-center gap-1">
+        <Megaphone className="w-4 h-4" />
+        <h3 className="font-semibold">Marketing Campaign ROI</h3>
+      </div>
+      <div>
+        <span className="font-semibold">${stats.spend} / ${stats.revenue}</span>
+        <div className="h-2 bg-gray-200 rounded mt-1">
+          <div className="h-2 bg-blue-500 rounded" style={{ width: `${pct}%` }} />
+        </div>
+      </div>
+      <div className="text-xs flex justify-between">
+        <span>CPL: ${stats.cpl}</span>
+        <span>ROI: {stats.roi}%</span>
+      </div>
+      <div className="h-24">
+        <ResponsiveContainer width="100%" height="100%">
+          <BarChart data={stats.conversionByChannel} layout="vertical">
+            <Tooltip />
+            <Bar dataKey="rate" fill="#3b82f6" />
+          </BarChart>
+        </ResponsiveContainer>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/SalesTeamActivity.jsx
+++ b/frontend/src/components/SalesTeamActivity.jsx
@@ -1,0 +1,66 @@
+import React, { useEffect, useState } from 'react';
+import { BarChart3 } from 'lucide-react';
+
+export default function SalesTeamActivity() {
+  const [stats, setStats] = useState({
+    unitsByRep: [],
+    grossPerUnit: 0,
+    closingRatio: 0,
+    fiPenetration: 0,
+    appraisalToTrade: '',
+  });
+
+  useEffect(() => {
+    const API_BASE = import.meta.env.PROD ? import.meta.env.VITE_API_BASE_URL : '/api';
+    const fetchStats = async () => {
+      try {
+        const res = await fetch(`${API_BASE}/analytics/sales-team-activity`);
+        if (!res.ok) return;
+        const data = await res.json();
+        setStats({
+          unitsByRep: Array.isArray(data.unitsByRep) ? data.unitsByRep : [],
+          grossPerUnit: data.grossPerUnit ?? 0,
+          closingRatio: data.closingRatio ?? 0,
+          fiPenetration: data.fiPenetration ?? 0,
+          appraisalToTrade: data.appraisalToTrade ?? '',
+        });
+      } catch (err) {
+        console.error(err);
+      }
+    };
+    fetchStats();
+  }, []);
+
+  return (
+    <div className="bg-white p-4 rounded-lg shadow space-y-3">
+      <div className="flex items-center gap-1">
+        <BarChart3 className="w-4 h-4" />
+        <h3 className="font-semibold">Sales Team Activity & Productivity</h3>
+      </div>
+      <table className="text-xs w-full">
+        <thead>
+          <tr className="text-left">
+            <th className="pr-2">Rep</th>
+            <th>Units</th>
+          </tr>
+        </thead>
+        <tbody>
+          {stats.unitsByRep.map((r) => (
+            <tr key={r.rep}>
+              <td className="pr-2">{r.rep}</td>
+              <td>{r.units}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <div className="text-xs flex justify-between">
+        <span>GP/Vehicle: ${stats.grossPerUnit}</span>
+        <span>Closing: {stats.closingRatio}%</span>
+      </div>
+      <div className="grid grid-cols-2 gap-2 text-xs">
+        <span>F&amp;I Penetration: {stats.fiPenetration}%</span>
+        <span>Appraisal/Trade: {stats.appraisalToTrade}</span>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/ServiceDepartmentPerformance.jsx
+++ b/frontend/src/components/ServiceDepartmentPerformance.jsx
@@ -1,0 +1,64 @@
+import React, { useState, useEffect } from 'react';
+import { Wrench } from 'lucide-react';
+import { ResponsiveContainer, BarChart, Bar, Tooltip } from 'recharts';
+
+export default function ServiceDepartmentPerformance() {
+  const [stats, setStats] = useState({
+    elr: 0,
+    hoursPerRo: 0,
+    grossProfitPct: 0,
+    csi: 0,
+    fixedCoverage: 0,
+  });
+
+  useEffect(() => {
+    const API_BASE = import.meta.env.PROD ? import.meta.env.VITE_API_BASE_URL : '/api';
+    const fetchStats = async () => {
+      try {
+        const res = await fetch(`${API_BASE}/analytics/service-performance`);
+        if (!res.ok) return;
+        const data = await res.json();
+        setStats({
+          elr: data.effectiveLaborRate ?? 0,
+          hoursPerRo: data.hoursPerRo ?? 0,
+          grossProfitPct: data.grossProfitPct ?? 0,
+          csi: data.csi ?? 0,
+          fixedCoverage: data.fixedCoverage ?? 0,
+        });
+      } catch (err) {
+        console.error(err);
+      }
+    };
+    fetchStats();
+  }, []);
+
+  const barData = [{ name: 'ELR', value: stats.elr }];
+
+  return (
+    <div className="bg-white p-4 rounded-lg shadow space-y-3">
+      <div className="flex items-center gap-1">
+        <Wrench className="w-4 h-4" />
+        <h3 className="font-semibold">Service Department Performance</h3>
+      </div>
+      <div>
+        <span className="text-xl font-bold">${stats.elr}/hr</span>
+        <div className="h-4">
+          <ResponsiveContainer width="100%" height="100%">
+            <BarChart data={barData} layout="vertical">
+              <Tooltip />
+              <Bar dataKey="value" fill="#3b82f6" />
+            </BarChart>
+          </ResponsiveContainer>
+        </div>
+      </div>
+      <div className="flex justify-between text-xs">
+        <span>Hours/RO: {stats.hoursPerRo} hrs</span>
+        <span>GP%: {stats.grossProfitPct}%</span>
+      </div>
+      <div className="text-xs space-y-1">
+        <div>CSI: {stats.csi}</div>
+        <div>FC: {stats.fixedCoverage}%</div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/routes/Home.jsx
+++ b/frontend/src/routes/Home.jsx
@@ -3,14 +3,22 @@ import SalesPerformanceKPI from '../components/SalesPerformanceKPI';
 import LeadPerformanceKPI from '../components/LeadPerformanceKPI';
 import InventorySnapshot from '../components/InventorySnapshot';
 import AIOverview from '../components/AIOverview';
+import ServiceDepartmentPerformance from '../components/ServiceDepartmentPerformance';
+import CustomerSatisfaction from '../components/CustomerSatisfaction';
+import MarketingCampaignROI from '../components/MarketingCampaignROI';
+import SalesTeamActivity from '../components/SalesTeamActivity';
 
 export default function Home() {
   return (
-    <div className="max-w-6xl mx-auto p-6 grid grid-cols-1 md:grid-cols-4 gap-4">
+    <div className="max-w-6xl mx-auto p-6 grid grid-cols-1 md:grid-cols-4 lg:grid-cols-8 gap-4">
       <SalesPerformanceKPI />
       <LeadPerformanceKPI />
       <InventorySnapshot />
       <AIOverview />
+      <ServiceDepartmentPerformance />
+      <CustomerSatisfaction />
+      <MarketingCampaignROI />
+      <SalesTeamActivity />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- extend dashboard grid to eight columns on large screens
- add Service Department Performance card
- add Customer Satisfaction & Retention card with modal
- add Marketing Campaign ROI card
- add Sales Team Activity & Productivity card

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f297d9cc483229ab8116eb27f2752