### PR TITLE
Fix nav overlap with page content

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -41,6 +41,8 @@ body {
   margin: 0;
   min-width: 320px;
   min-height: 100vh;
+  /* prevent content from sitting underneath the fixed header */
+  padding-top: 5rem;
 }
 
 #root {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -42,7 +42,7 @@ body {
   min-width: 320px;
   min-height: 100vh;
   /* prevent content from sitting underneath the fixed header */
-  padding-top: 5rem;
+  padding-top: var(--header-height); /* Use the CSS variable for header height */
 }
 
 #root {


### PR DESCRIPTION
## Summary
- add padding to body so content clears the fixed navigation bar

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872afabedb08322a4a28a610ca8ec10