### PR TITLE
Add floor traffic date range filter

### DIFF
--- a/tests/test_floor_traffic.py
+++ b/tests/test_floor_traffic.py
@@ -156,3 +156,40 @@ def test_month_metrics():
         "write_up_count": 1,
         "sold_count": 1,
     }
+
+
+def test_search_floor_traffic():
+    sample = [
+        {
+            "id": "1",
+            "salesperson": "Bob",
+            "customer_name": "Alice",
+            "first_name": None,
+            "last_name": None,
+            "email": None,
+            "phone": None,
+            "visit_time": "2024-01-05T09:00:00",
+            "time_out": None,
+            "demo": None,
+            "worksheet": None,
+            "customer_offer": None,
+            "notes": None,
+            "created_at": "2024-01-05T09:00:00",
+        }
+    ]
+
+    exec_result = MagicMock(data=sample, error=None)
+    mock_table = MagicMock()
+    (
+        mock_table.select.return_value.gte.return_value.lt.return_value.order.return_value.execute.return_value
+    ) = exec_result
+    mock_supabase = MagicMock()
+    mock_supabase.table.return_value = mock_table
+
+    with patch("app.routers.floor_traffic.supabase", mock_supabase):
+        response = client.get(
+            "/api/floor-traffic/search?start=2024-01-05&end=2024-01-05"
+        )
+
+    assert response.status_code == 200
+    assert response.json() == sample


### PR DESCRIPTION
## Summary
- allow searching floor traffic entries by date range via new `/search` endpoint
- support date range filtering in frontend floor traffic page
- update tests for the new endpoint

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872b45d850c83228cc9c51dc25e2d5f