### PR TITLE
Add inventory type support

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -225,6 +225,7 @@ class InventoryItem(CamelModel):
     mileage: Optional[int] = None
     color: Optional[str] = None
     condition: Optional[str] = None
+    inventory_type: Optional[str] = None
     fuel_type: Optional[str] = None
     drivetrain: Optional[str] = None
     active: Optional[bool] = True
@@ -245,6 +246,7 @@ class InventoryItemCreate(CamelModel):
     mileage: Optional[int] = None
     color: Optional[str] = None
     condition: Optional[str] = None
+    inventory_type: Optional[str] = None
     fuel_type: Optional[str] = None
     drivetrain: Optional[str] = None
     active: Optional[bool] = True
@@ -265,6 +267,7 @@ class InventoryItemUpdate(CamelModel):
     mileage: Optional[int] = None
     color: Optional[str] = None
     condition: Optional[str] = None
+    inventory_type: Optional[str] = None
     fuel_type: Optional[str] = None
     drivetrain: Optional[str] = None
     active: Optional[bool] = None

--- a/app/routers/analytics.py
+++ b/app/routers/analytics.py
@@ -67,10 +67,10 @@ def inventory_overview():
     try:
         snapshot = inventory.inventory_snapshot()
     except Exception:
-        snapshot = {"total": 0, "active": 0, "inactive": 0}
+        snapshot = {"total": 0, "new": 0, "used": 0}
     total = snapshot.get("total", 0)
-    new_count = snapshot.get("active", 0)
-    used_count = total - new_count
+    new_count = snapshot.get("new", 0)
+    used_count = snapshot.get("used", 0)
     return {
         "total": total,
         "newCount": new_count,


### PR DESCRIPTION
## Summary
- expose `inventory_type` field on inventory models
- filter by `inventory_type` when listing inventory
- update inventory snapshot to count new vs used vehicles
- update analytics overview for new/used counts
- adjust tests for new field and metrics

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872b642cb388322acd9435ca43c4690