### PR TITLE
Add inventory type display

### DIFF
--- a/frontend/src/components/InventoryCard.jsx
+++ b/frontend/src/components/InventoryCard.jsx
@@ -33,6 +33,7 @@ export default function InventoryCard({ vehicle, onEdit, onToggle }) {
     additionalImageLink8,
     exteriorColor,
     interiorColor,
+    inventoryType,
     active,
   } = vehicle;
 
@@ -153,6 +154,12 @@ export default function InventoryCard({ vehicle, onEdit, onToggle }) {
         {trim && (
           <p className="flex items-center gap-1">
             <Tag className="w-4 h-4" /> Trim: {trim}
+          </p>
+        )}
+
+        {inventoryType && (
+          <p className="flex items-center gap-1">
+            <Tag className="w-4 h-4" /> Type: {inventoryType}
           </p>
         )}
 


### PR DESCRIPTION
## Summary
- surface `inventoryType` field in inventory cards

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872b9cb8d188322ae02563fb3fe9d15