### PR TITLE
Improve visitors KPI on floor log page

### DIFF
--- a/frontend/src/routes/FloorLog.jsx
+++ b/frontend/src/routes/FloorLog.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { Users } from 'lucide-react';
 
 export default function FloorLog() {
   const [logs, setLogs] = useState([]);
@@ -31,11 +32,41 @@ export default function FloorLog() {
     { key: 'origin', label: 'Orig' },
   ];
 
+  const totalCustomers = logs.length;
+  const inStoreCount = logs.filter(l => !l.timeOut).length;
+  const demoCount = logs.filter(l => l.demo).length;
+  const worksheetCount = logs.filter(
+    l => l.writeUp || l.worksheet || l.worksheet_complete || l.worksheetComplete || l.write_up
+  ).length;
+  const offerCount = logs.filter(l => l.customerOffer || l.customer_offer).length;
+  const soldCount = logs.filter(l => l.sold).length;
+  const pct = c => (totalCustomers ? Math.round((c / totalCustomers) * 100) : 0);
+
+  const kpiClass =
+    'flex-1 rounded-3xl p-6 bg-gradient-to-br from-electricblue via-darkblue to-slategray text-white shadow-lg hover:shadow-xl hover:-translate-y-1 transition-transform';
+
   return (
     <div className="w-full min-h-screen bg-offwhite dark:bg-gray-800 p-4">
       <h1 className="text-2xl lg:text-3xl font-bold text-gray-800 dark:text-gray-100 mb-6">
         Floor Log
       </h1>
+      <div className="mb-6 grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
+        <div className={kpiClass}>
+          <div className="flex items-center gap-2 opacity-90">
+            <Users className="w-5 h-5" />
+            <p className="uppercase tracking-wider text-sm font-medium">Visitors</p>
+          </div>
+          <p className="text-4xl font-bold mt-2">{totalCustomers}</p>
+          <ul className="mt-4 space-y-1 text-sm text-white/90">
+            <li>{totalCustomers} Customers</li>
+            <li>{inStoreCount} In Store</li>
+            <li>{demoCount} Demo ({pct(demoCount)}%)</li>
+            <li>{worksheetCount} Worksheet ({pct(worksheetCount)}%)</li>
+            <li>{offerCount} Customer Offer ({pct(offerCount)}%)</li>
+            <li>{soldCount} Sold ({pct(soldCount)}%)</li>
+          </ul>
+        </div>
+      </div>
       <div className="w-full bg-white dark:bg-gray-900 shadow-lg rounded-lg p-4 lg:p-6 overflow-x-auto">
         <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
           <thead className="bg-electricblue dark:bg-darkblue sticky top-0 z-10 text-white">


### PR DESCRIPTION
## Summary
- add dynamic visitor KPI display to FloorLog page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872bb2beaac832285d9ac38dee144b0