### PR TITLE
Graceful supabase failures & customer route tweak

### DIFF
--- a/app/routers/floor_traffic.py
+++ b/app/routers/floor_traffic.py
@@ -170,7 +170,14 @@ def month_metrics():
             .execute()
         )
     except APIError as e:
-        raise HTTPException(status_code=500, detail=e.message)
+        logging.error("Supabase query failed: %s", e.message)
+        return {
+            "total_customers": 0,
+            "demo_count": 0,
+            "worksheet_count": 0,
+            "customer_offer_count": 0,
+            "sold_count": 0,
+        }
 
     rows = res.data or []
     total = len(rows)

--- a/app/routers/leads.py
+++ b/app/routers/leads.py
@@ -228,7 +228,13 @@ def month_metrics():
             .execute()
         )
     except APIError as e:
-        raise HTTPException(status_code=500, detail=e.message)
+        logging.error("Supabase query failed: %s", e.message)
+        return {
+            "total_leads": 0,
+            "conversion_rate": 0,
+            "average_response_time": 0,
+            "lead_engagement_rate": 0,
+        }
 
     rows = res.data or []
     total = len(rows)

--- a/routes/customers.js
+++ b/routes/customers.js
@@ -4,7 +4,7 @@ import supabase from '../lib/supabaseClient.js';
 const router = express.Router();
 
 // GET /api/customers
-router.get('/customers', async (req, res, next) => {
+router.get(['/customers', '/customers/'], async (req, res, next) => {
   try {
     const { q, email, phone } = req.query;
     let query = supabase.from('customers').select('*');
@@ -37,7 +37,7 @@ router.get('/customers/:id', async (req, res, next) => {
 });
 
 // POST /api/customers
-router.post('/customers', async (req, res, next) => {
+router.post(['/customers', '/customers/'], async (req, res, next) => {
   try {
     const payload = req.body;
     const { data, error } = await supabase


### PR DESCRIPTION
## Summary
- log Supabase errors and return zeroed metrics to avoid 500s in `floor_traffic.month_metrics` and `leads.month_metrics`
- accept `/customers/` with optional trailing slash in Express API

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872bd16b4148322bb2828b055fb7ace