### PR TITLE
Fix missing customer names in API responses

### DIFF
--- a/routes/customers.js
+++ b/routes/customers.js
@@ -16,7 +16,7 @@ router.get('/customers', async (req, res, next) => {
     const rows = Array.isArray(data) ? data : [];
     const customers = rows.map(c => ({
       ...c,
-      name: c.name || [c.first_name, c.last_name].filter(Boolean).join(' ').trim()
+      name: normalizeCustomerName(c)
     }));
     res.json(customers);
   } catch (err) {

--- a/routes/customers.js
+++ b/routes/customers.js
@@ -13,7 +13,12 @@ router.get('/customers', async (req, res, next) => {
     if (phone) query = query.ilike('phone', `%${phone}%`);
     const { data, error } = await query;
     if (error) throw error;
-    res.json(Array.isArray(data) ? data : []);
+    const rows = Array.isArray(data) ? data : [];
+    const customers = rows.map(c => ({
+      ...c,
+      name: c.name || [c.first_name, c.last_name].filter(Boolean).join(' ').trim()
+    }));
+    res.json(customers);
   } catch (err) {
     next(err);
   }
@@ -30,7 +35,11 @@ router.get('/customers/:id', async (req, res, next) => {
       .maybeSingle();
     if (error) throw error;
     if (!data) return res.status(404).json({ message: 'Customer not found' });
-    res.json(data);
+    const customer = {
+      ...data,
+      name: data.name || [data.first_name, data.last_name].filter(Boolean).join(' ').trim(),
+    };
+    res.json(customer);
   } catch (err) {
     next(err);
   }

--- a/routes/customers.js
+++ b/routes/customers.js
@@ -37,7 +37,7 @@ router.get('/customers/:id', async (req, res, next) => {
     if (!data) return res.status(404).json({ message: 'Customer not found' });
     const customer = {
       ...data,
-      name: data.name || [data.first_name, data.last_name].filter(Boolean).join(' ').trim(),
+      name: data.name || [data.first_name, data.last_name].filter(Boolean).join(' ').trim() || 'Unknown Customer',
     };
     res.json(customer);
   } catch (err) {


### PR DESCRIPTION
## Summary
- normalize customer data so name always exists
- update customer fetch endpoint to populate `name` from first/last name when missing
- update single customer endpoint similarly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872bcf932448322b0310a13bc502211