### PR TITLE
Rename condition labels to type

### DIFF
--- a/frontend/src/components/FilterPanel.jsx
+++ b/frontend/src/components/FilterPanel.jsx
@@ -31,7 +31,7 @@ export default function FilterPanel({ filters, onChange, options = {} }) {
   return (
     <div className="grid grid-cols-2 md:grid-cols-4 gap-4 bg-gray-50 dark:bg-gray-800 p-4 rounded-lg">
       <div>
-        <label className="block mb-1 text-sm">Condition</label>
+        <label className="block mb-1 text-sm">Type</label>
         <div className="flex gap-2">
           {['New', 'Used', 'Certified'].map(c => (
             <label key={c} className="text-sm flex items-center gap-1">

--- a/frontend/src/components/VehicleModal.jsx
+++ b/frontend/src/components/VehicleModal.jsx
@@ -74,7 +74,7 @@ export default function VehicleModal({ isOpen, onClose, onSubmit, initialData })
             ['price','Price','number'],
             ['mileage','Mileage','number'],
             ['color','Color','text'],
-            ['condition','Condition','text'],
+            ['condition','Type','text'],
             ['fuelType','Fuel Type','text'],
             ['drivetrain','Drivetrain','text'],
           ].map(([name,label,type]) => (


### PR DESCRIPTION
## Summary
- rename filter heading 'Condition' to 'Type'
- rename vehicle modal field label from 'Condition' to 'Type'

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872bcc456e88322a6041b52f79617ce