### PR TITLE
Remove react-avatar from lock file

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13,7 +13,6 @@
         "lucide-react": "^0.525.0",
         "peerjs": "^1.5.5",
         "react": "^19.1.0",
-        "react-avatar": "^5.0.3",
         "react-countup": "^6.5.3",
         "react-dom": "^19.1.0",
         "react-hot-toast": "^2.5.2",
@@ -3848,21 +3847,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/react-avatar": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/react-avatar/-/react-avatar-5.0.3.tgz",
-      "integrity": "sha512-DNc+qkWH9QehSEZqHBhqpXWsPY+rU9W7kD68QFHfu8Atfsvx/3ML0DzAePgTUd96nCXQQ3KZMcC3LKYT8FiBIg==",
-      "dependencies": {
-        "is-retina": "^1.0.3",
-        "md5": "^2.0.0"
-      },
-      "peerDependencies": {
-        "@babel/runtime": ">=7",
-        "core-js-pure": ">=3",
-        "prop-types": "^15.0.0 || ^16.0.0",
-        "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/react-countup": {


### PR DESCRIPTION
## Summary
- remove react-avatar package entry from frontend

## Testing
- `pytest -q` *(fails: test_search_customers, test_get_customer, test_get_today_floor_traffic, test_create_floor_traffic, test_update_floor_traffic, test_search_floor_traffic, test_list_inventory, test_create_inventory, test_inventory_snapshot)*

------
https://chatgpt.com/codex/tasks/task_e_687695a576c88322aecc92ee56caa154