### PR TITLE
Implement customer file upload endpoint

### DIFF
--- a/app/routers/appointments.py
+++ b/app/routers/appointments.py
@@ -19,6 +19,7 @@ class Appointment(AppointmentCreate):
     id: int
 
 @router.get("/", response_model=list[Appointment])
+@router.get("", response_model=list[Appointment], include_in_schema=False)
 def list_appointments(customer_id: Optional[int] = None):
     try:
         query = supabase.table("appointments").select("*")
@@ -30,6 +31,7 @@ def list_appointments(customer_id: Optional[int] = None):
         raise HTTPException(400, detail=e.message)
 
 @router.post("/", response_model=Appointment)
+@router.post("", response_model=Appointment, include_in_schema=False)
 def create_appointment(appt: AppointmentCreate):
     try:
         res = supabase.table("appointments").insert(appt.dict()).execute()

--- a/app/routers/customers.py
+++ b/app/routers/customers.py
@@ -1,7 +1,9 @@
 print("CUSTOMERS ROUTER LOADED")
-from fastapi import APIRouter, HTTPException, status, Query
+from fastapi import APIRouter, HTTPException, status, Query, UploadFile, File
 from postgrest.exceptions import APIError
 from app.db import supabase
+from pydantic import BaseModel
+import uuid
 from app.models import Customer, CustomerCreate, CustomerUpdate
 from app.openai_client import get_openai_client
 import json
@@ -211,3 +213,49 @@ async def customer_ai_summary(customer_id: int):
         return data
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
+
+
+class CustomerFile(BaseModel):
+    id: int
+    customer_id: int
+    name: str
+    url: str
+
+
+@router.get("/{customer_id}/files", response_model=list[CustomerFile])
+def list_customer_files(customer_id: int):
+    """Return files uploaded for a customer."""
+    try:
+        res = (
+            supabase.table("customer_files")
+            .select("*")
+            .eq("customer_id", customer_id)
+            .execute()
+        )
+        return res.data or []
+    except APIError as e:
+        raise HTTPException(status_code=400, detail=e.message)
+
+
+@router.post(
+    "/{customer_id}/files",
+    response_model=CustomerFile,
+    status_code=status.HTTP_201_CREATED,
+)
+def upload_customer_file(customer_id: int, file: UploadFile = File(...)):
+    """Upload a document for the customer."""
+    try:
+        content = file.file.read()
+        filename = f"{uuid.uuid4()}_{file.filename}"
+        path = f"{customer_id}/{filename}"
+        bucket = supabase.storage.from_("customer-files")
+        bucket.upload(path, content, {"content-type": file.content_type})
+        url = bucket.get_public_url(path)
+        res = (
+            supabase.table("customer_files")
+            .insert({"customer_id": customer_id, "name": file.filename, "url": url})
+            .execute()
+        )
+        return res.data[0]
+    except APIError as e:
+        raise HTTPException(status_code=400, detail=e.message)

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ email-validator>=1.3.0
 openai
 httpx<0.28
 twilio
+python-multipart


### PR DESCRIPTION
## Summary
- support `/api/appointments` without trailing slash
- allow uploading and listing customer documents
- add `python-multipart` dependency for file uploads

## Testing
- `pytest -q` *(fails: test_chat_endpoint, test_search_customers, test_get_customer, test_get_today_floor_traffic, test_create_floor_traffic, test_update_floor_traffic, test_search_floor_traffic, test_list_inventory, test_create_inventory, test_inventory_snapshot)*

------
https://chatgpt.com/codex/tasks/task_e_6877b4229f1083228e98e8812e9f815e