### PR TITLE
Add activity logging to customer card

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -116,33 +116,37 @@ class OpportunityUpdate(BaseModel):
 # ── Activities ─────────────────────────────────────────────────────────────────
 class Activity(BaseModel):
     id: str
-    activity_type: str        # e.g. "call", "email", "task"
-    subject: str
-    note: Optional[str]
+    activity_type: str        # e.g. "call", "email", "task", "view"
+    subject: Optional[str] = None
+    note: Optional[str] = None
     customer_id: Optional[int] = None
-    related_lead_id: Optional[int]
-    related_contact_id: Optional[int]
-    related_account_id: Optional[int]
-    related_opportunity_id: Optional[int]
+    user_id: Optional[int] = None
+    created_at: Optional[datetime] = None
+    related_lead_id: Optional[int] = None
+    related_contact_id: Optional[int] = None
+    related_account_id: Optional[int] = None
+    related_opportunity_id: Optional[int] = None
 
 class ActivityCreate(BaseModel):
     activity_type: str
-    subject: str
+    subject: Optional[str] = None
     note: Optional[str]
     customer_id: Optional[int] = None
-    related_lead_id: Optional[int]
-    related_contact_id: Optional[int]
-    related_account_id: Optional[int]
-    related_opportunity_id: Optional[int]
+    user_id: Optional[int] = None
+    related_lead_id: Optional[int] = None
+    related_contact_id: Optional[int] = None
+    related_account_id: Optional[int] = None
+    related_opportunity_id: Optional[int] = None
 
 class ActivityUpdate(BaseModel):
     customer_id: Optional[int] = None
-    contact_id: Optional[str]
-    opportunity_id: Optional[str]
-    activity_type: Optional[str]
-    subject: Optional[str]
-    note: Optional[str]
-    date: Optional[date]
+    contact_id: Optional[str] = None
+    opportunity_id: Optional[str] = None
+    activity_type: Optional[str] = None
+    subject: Optional[str] = None
+    note: Optional[str] = None
+    user_id: Optional[int] = None
+    date: Optional[date] = None
 
 
 # ── Floor Traffic Log ─────────────────────────────────────────────────────────

--- a/app/routers/activities.py
+++ b/app/routers/activities.py
@@ -66,7 +66,7 @@ def get_activity(act_id: int):
 @router.post("/", response_model=Activity, status_code=status.HTTP_201_CREATED)
 def create_activity(a: ActivityCreate):
     try:
-        res = supabase.table("activities").insert(a.dict()).execute()
+        res = supabase.table("activities").insert(a.dict(exclude_none=True)).execute()
     except APIError as e:
         raise HTTPException(status_code=400, detail=e.message)
     return res.data[0]

--- a/frontend/src/components/CustomerProfileCard.jsx
+++ b/frontend/src/components/CustomerProfileCard.jsx
@@ -122,6 +122,19 @@ export default function CustomerProfileCard({ customer, ledger = [], onSave }) {
   const [editMode, setEditMode] = useState(false);
   const [form, setForm] = useState(customer);
   const [activeTab, setActiveTab] = useState("Details");
+  const API_BASE = import.meta.env.VITE_API_BASE_URL || '/api'
+  const CURRENT_USER_ID = 1
+
+  const logActivity = async (type, note = '', subject = '') => {
+    const payload = { activity_type: type, note, subject, customer_id: customer?.id, user_id: CURRENT_USER_ID }
+    try {
+      await fetch(`${API_BASE}/activities`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload)
+      })
+    } catch {}
+  }
 
   // Simulated tags: you might fetch or compute these
   const tags = [
@@ -136,6 +149,9 @@ export default function CustomerProfileCard({ customer, ledger = [], onSave }) {
 
   useEffect(() => {
     setForm(customer);
+    if (customer?.id) {
+      logActivity('view', '', 'Viewed customer card');
+    }
   }, [customer]);
 
   function handleFieldChange(key, value) {
@@ -154,14 +170,14 @@ export default function CustomerProfileCard({ customer, ledger = [], onSave }) {
           <>
             <button
               className="rounded-full p-2 hover:bg-blue-100"
-              onClick={() => (window.location.href = `tel:${phone}`)}
+              onClick={() => { logActivity('call', '', 'Phone call'); window.location.href = `tel:${phone}` }}
               title="Call"
             >
               <Phone className="w-4 h-4" />
             </button>
             <button
               className="rounded-full p-2 hover:bg-blue-100"
-              onClick={() => (window.location.href = `sms:${phone}`)}
+              onClick={() => { logActivity('text', '', 'Text message'); window.location.href = `sms:${phone}` }}
               title="Text"
             >
               <MessageCircle className="w-4 h-4" />
@@ -171,7 +187,7 @@ export default function CustomerProfileCard({ customer, ledger = [], onSave }) {
         {email && (
           <button
             className="rounded-full p-2 hover:bg-blue-100"
-            onClick={() => (window.location.href = `mailto:${email}`)}
+            onClick={() => { logActivity('email', '', 'Email'); window.location.href = `mailto:${email}` }}
             title="Email"
           >
             <Mail className="w-4 h-4" />

--- a/tests/test_activities.py
+++ b/tests/test_activities.py
@@ -1,5 +1,6 @@
 from fastapi.testclient import TestClient
 from unittest.mock import MagicMock, patch
+import json
 from app.main import app
 
 client = TestClient(app)
@@ -28,3 +29,39 @@ def test_today_metrics():
         "text_messages": 1,
         "appointments_set": 1,
     }
+
+
+def test_create_activity_with_user():
+    sample = {
+        "id": "1",
+        "activity_type": "call",
+        "subject": "Call",
+        "note": "Test",
+        "customer_id": 1,
+        "user_id": 5,
+    }
+    exec_result = MagicMock(data=[sample], error=None)
+    mock_table = MagicMock()
+    mock_table.insert.return_value.execute.return_value = exec_result
+    mock_supabase = MagicMock()
+    mock_supabase.table.return_value = mock_table
+
+    payload = {
+        "activity_type": "call",
+        "subject": "Call",
+        "note": "Test",
+        "customer_id": 1,
+        "user_id": 5,
+    }
+    with patch("app.routers.activities.supabase", mock_supabase):
+        response = client.post(
+            "/api/activities/",
+            content=json.dumps(payload),
+            headers={"Content-Type": "application/json"},
+        )
+
+    assert response.status_code == 201
+    data = response.json()
+    assert data["activity_type"] == "call"
+    assert data["user_id"] == 5
+    mock_table.insert.assert_called_with(payload)


### PR DESCRIPTION
## Summary
- extend activity models with `user_id` and `created_at`
- save activities with optional fields ignored
- log customer card events from the React UI
- update customer profile component to log communication actions
- test posting activity with user information

## Testing
- `pytest -q` *(fails: test_chat_endpoint, test_search_customers, test_get_customer, test_get_today_floor_traffic, test_create_floor_traffic, test_update_floor_traffic, test_search_floor_traffic, test_list_inventory, test_create_inventory, test_inventory_snapshot)*

------
https://chatgpt.com/codex/tasks/task_e_6877bf0be1848322ba046517537f95b4