### PR TITLE
Fix Supabase metrics query

### DIFF
--- a/app/routers/leads.py
+++ b/app/routers/leads.py
@@ -222,7 +222,7 @@ def month_metrics():
     try:
         res = (
             supabase.table("leads")
-            .select("created_at,last_lead_response_at,last_staff_response_at")
+            .select("*")
             .gte("created_at", start.isoformat())
             .lt("created_at", end.isoformat())
             .execute()


### PR DESCRIPTION
## Summary
- avoid selecting non-existent columns for monthly lead metrics

## Testing
- `pytest -q` *(fails: ResponseValidationError, AssertionError, KeyError)*

------
https://chatgpt.com/codex/tasks/task_e_6877f904c884832295214412e7c92dec