### PR TITLE
Add floor log endpoint

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -2,7 +2,7 @@
 
 from datetime import date, datetime, time
 from typing import Optional, List
-from pydantic import BaseModel, EmailStr, root_validator, validator, ConfigDict
+from pydantic import BaseModel, EmailStr, root_validator, validator, ConfigDict, Field
 
 # ── Analytics Schema ─────────────────────────────────────────────────────────
 class MonthMetrics(BaseModel):
@@ -146,7 +146,7 @@ class ActivityUpdate(BaseModel):
 class FloorTrafficCustomer(BaseModel):
     id: str
     salesperson: str
-    name: str
+    name: str = Field(alias="customer_name")
     first_name: Optional[str] = None
     last_name: Optional[str] = None
     email: Optional[EmailStr] = None
@@ -156,8 +156,10 @@ class FloorTrafficCustomer(BaseModel):
     demo: Optional[bool] = None
     worksheet: Optional[bool] = None
     customer_offer: Optional[bool] = None
+    status: Optional[str] = None
     notes: Optional[str] = None
     created_at: datetime
+    model_config = ConfigDict(populate_by_name=True)
 
 class FloorTrafficCustomerCreate(BaseModel):
     visit_time: datetime
@@ -169,6 +171,7 @@ class FloorTrafficCustomerCreate(BaseModel):
     demo: Optional[bool] = None
     worksheet: Optional[bool] = None
     customer_offer: Optional[bool] = None
+    status: Optional[str] = None
     notes: Optional[str] = None
     time_out: Optional[datetime] = None
 
@@ -189,7 +192,20 @@ class FloorTrafficCustomerUpdate(BaseModel):
     demo: Optional[bool] = None
     worksheet: Optional[bool] = None
     customer_offer: Optional[bool] = None
+    status: Optional[str] = None
     notes: Optional[str] = None
+
+
+class CustomerFloorTrafficCreate(BaseModel):
+    """Simplified payload when logging an existing customer."""
+    visit_time: datetime
+    salesperson: str
+    demo: Optional[bool] = None
+    worksheet: Optional[bool] = None
+    customer_offer: Optional[bool] = None
+    status: Optional[str] = None
+    notes: Optional[str] = None
+    time_out: Optional[datetime] = None
 
 
 # ── Inventory ─────────────────────────────────────────────────────────────────

--- a/app/routers/customers.py
+++ b/app/routers/customers.py
@@ -1,8 +1,15 @@
 print("CUSTOMERS ROUTER LOADED")
 from fastapi import APIRouter, HTTPException, status, Query
+from datetime import datetime, timedelta
 from postgrest.exceptions import APIError
 from app.db import supabase
-from app.models import Customer, CustomerCreate, CustomerUpdate
+from app.models import (
+    Customer,
+    CustomerCreate,
+    CustomerUpdate,
+    CustomerFloorTrafficCreate,
+    FloorTrafficCustomer,
+)
 from app.openai_client import get_openai_client
 import json
 
@@ -211,3 +218,71 @@ async def customer_ai_summary(customer_id: int):
         return data
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.post(
+    "/{customer_id}/floor-traffic",
+    response_model=FloorTrafficCustomer,
+    status_code=status.HTTP_201_CREATED,
+)
+async def add_customer_to_floor_log(customer_id: int, entry: CustomerFloorTrafficCreate):
+    """Create a floor-traffic entry for an existing customer."""
+    # Fetch customer record
+    try:
+        res = (
+            supabase.table("customers")
+            .select("*")
+            .eq("id", customer_id)
+            .maybe_single()
+            .execute()
+        )
+    except APIError as e:
+        raise HTTPException(status_code=400, detail=e.message)
+
+    if not res.data:
+        raise HTTPException(status_code=404, detail="Customer not found")
+
+    customer = res.data
+    first = customer.get("first_name") or ""
+    last = customer.get("last_name") or ""
+
+    # Determine if they've visited in last 30 days
+    thirty_days_ago = datetime.utcnow() - timedelta(days=30)
+    try:
+        past = (
+            supabase.table("floor_traffic_customers")
+            .select("id")
+            .eq("first_name", first)
+            .eq("last_name", last)
+            .gte("visit_time", thirty_days_ago.isoformat())
+            .limit(1)
+            .execute()
+        )
+        be_back = bool(past.data)
+    except APIError as e:
+        raise HTTPException(status_code=400, detail=e.message)
+
+    payload = entry.dict(exclude_unset=True)
+    payload.update(
+        {
+            "first_name": first,
+            "last_name": last,
+            "email": customer.get("email"),
+            "phone": customer.get("phone"),
+            "customer_name": (first + " " + last).strip() or customer.get("name"),
+            "status": "Be-Back" if be_back else entry.status or None,
+        }
+    )
+
+    try:
+        res = supabase.table("floor_traffic_customers").insert(payload).execute()
+    except APIError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+    if not res.data:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Database insertion failed, no data returned.",
+        )
+
+    return res.data[0]

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -9,11 +9,12 @@ client = TestClient(app)
 def test_chat_endpoint():
     mock_resp = SimpleNamespace(choices=[SimpleNamespace(message=SimpleNamespace(content="hello"))])
     mock_client = SimpleNamespace(
-        chat=SimpleNamespace(
-            completions=SimpleNamespace(create=AsyncMock(return_value=mock_resp))
-        )
+        responses=SimpleNamespace(create=AsyncMock(return_value=mock_resp))
     )
-    with patch("app.routers.chat.get_openai_client", return_value=mock_client):
+    with (
+        patch("app.routers.chat.get_openai_client", return_value=mock_client),
+        patch("app.routers.chat.get_openai_prompt", return_value={"id": "1", "version": "v"})
+    ):
         response = client.post(
             "/api/chat/",
             content=b'{"message":"hi"}',

--- a/tests/test_customers.py
+++ b/tests/test_customers.py
@@ -1,12 +1,13 @@
 from fastapi.testclient import TestClient
 from unittest.mock import MagicMock, patch
+import json
 from app.main import app
 client = TestClient(app)
 
 
 def test_search_customers():
     sample = [{
-        "id": "1",
+        "id": 1,
         "name": "Alice",
         "email": "a@example.com",
         "phone": "123",
@@ -32,7 +33,7 @@ def test_search_customers():
 
 def test_get_customer():
     sample = {
-        "id": "1",
+        "id": 1,
         "name": "Alice",
         "email": "a@example.com",
         "phone": "123",
@@ -53,3 +54,65 @@ def test_get_customer():
     assert response.status_code == 200
     assert response.json() == sample
     mock_select.eq.assert_called_with("id", 1)
+
+
+def test_add_customer_to_floor_log_be_back():
+    customer = {
+        "id": 1,
+        "first_name": "Alice",
+        "last_name": "Smith",
+        "email": "a@example.com",
+        "phone": "123",
+        "name": "Alice Smith",
+    }
+
+    inserted = {
+        "id": "101",
+        "salesperson": "Bob",
+        "first_name": "Alice",
+        "last_name": "Smith",
+        "customer_name": "Alice Smith",
+        "email": "a@example.com",
+        "phone": "123",
+        "visit_time": "2024-01-10T10:00:00",
+        "time_out": None,
+        "demo": None,
+        "worksheet": None,
+        "customer_offer": None,
+        "status": "Be-Back",
+        "notes": None,
+        "created_at": "2024-01-10T10:00:00",
+    }
+
+    mock_customer_table = MagicMock()
+    (
+        mock_customer_table.select.return_value.eq.return_value.maybe_single.return_value.execute.return_value
+    ) = MagicMock(data=customer, error=None)
+
+    mock_floor_table = MagicMock()
+    (
+        mock_floor_table.select.return_value.eq.return_value.eq.return_value.gte.return_value.limit.return_value.execute.return_value
+    ) = MagicMock(data=[{"id": "old"}], error=None)
+    mock_floor_table.insert.return_value.execute.return_value = MagicMock(data=[inserted], error=None)
+
+    def table_side_effect(name):
+        if name == "customers":
+            return mock_customer_table
+        elif name == "floor_traffic_customers":
+            return mock_floor_table
+        return MagicMock()
+
+    mock_supabase = MagicMock()
+    mock_supabase.table.side_effect = table_side_effect
+
+    payload = {"visit_time": inserted["visit_time"], "salesperson": "Bob"}
+
+    with patch("app.routers.customers.supabase", mock_supabase):
+        response = client.post(
+            "/api/customers/1/floor-traffic",
+            content=json.dumps(payload),
+            headers={"Content-Type": "application/json"},
+        )
+
+    assert response.status_code == 201
+    assert response.json() == inserted

--- a/tests/test_floor_traffic.py
+++ b/tests/test_floor_traffic.py
@@ -20,6 +20,7 @@ def test_get_today_floor_traffic():
         "demo": None,
         "worksheet": None,
         "customer_offer": None,
+        "status": None,
         "notes": None,
         "created_at": "2024-01-01T09:00:00"
     }]
@@ -51,6 +52,7 @@ def test_create_floor_traffic():
         "demo": None,
         "worksheet": None,
         "customer_offer": None,
+        "status": None,
         "notes": None,
         "created_at": "2024-01-01T10:00:00",
     }
@@ -111,6 +113,7 @@ def test_update_floor_traffic():
         "demo": None,
         "worksheet": None,
         "customer_offer": None,
+        "status": None,
         "notes": "Updated",
         "created_at": "2024-01-01T10:00:00",
     }
@@ -174,6 +177,7 @@ def test_search_floor_traffic():
             "demo": None,
             "worksheet": None,
             "customer_offer": None,
+            "status": None,
             "notes": None,
             "created_at": "2024-01-05T09:00:00",
         }

--- a/tests/test_inventory.py
+++ b/tests/test_inventory.py
@@ -7,7 +7,7 @@ client = TestClient(app)
 
 
 def test_list_inventory():
-    sample = [{"id": 1, "stockNumber": "A123", "inventory_type": "new"}]
+    sample = [{"id": 1, "stocknumber": "A123", "type": "new"}]
     exec_result = MagicMock(data=sample, error=None)
     mock_table = MagicMock()
     mock_table.select.return_value.execute.return_value = exec_result
@@ -20,19 +20,19 @@ def test_list_inventory():
     assert response.status_code == 200
     data = response.json()
     assert isinstance(data, list)
-    assert data[0]["stockNumber"] == "A123"
-    assert data[0]["inventoryType"] == "new"
+    assert data[0]["stocknumber"] == "A123"
+    assert data[0]["type"] == "new"
 
 
 def test_create_inventory():
-    sample = {"id": 1, "stockNumber": "A123", "inventory_type": "used"}
+    sample = {"id": 1, "stocknumber": "A123", "type": "used"}
     exec_result = MagicMock(data=[sample], error=None)
     mock_table = MagicMock()
     mock_table.insert.return_value.execute.return_value = exec_result
     mock_supabase = MagicMock()
     mock_supabase.table.return_value = mock_table
 
-    payload = {"stockNumber": "A123", "inventoryType": "used"}
+    payload = {"stocknumber": "A123", "type": "used"}
     with patch("app.routers.inventory.supabase", mock_supabase):
         response = client.post(
             "/api/inventory/",
@@ -42,8 +42,8 @@ def test_create_inventory():
 
     assert response.status_code == 201
     data = response.json()
-    assert data["stockNumber"] == "A123"
-    assert data["inventoryType"] == "used"
+    assert data["stocknumber"] == "A123"
+    assert data["type"] == "used"
 
 
 def test_filter_inventory_query_params():
@@ -71,9 +71,9 @@ def test_filter_inventory_query_params():
 
 def test_inventory_snapshot():
     sample = [
-        {"inventory_type": "new"},
-        {"inventory_type": "used"},
-        {"inventory_type": "new"},
+        {"type": "new"},
+        {"type": "used"},
+        {"type": "new"},
     ]
     exec_result = MagicMock(data=sample, error=None)
     mock_table = MagicMock()


### PR DESCRIPTION
## Summary
- extend floor traffic models with a `status` field
- add `CustomerFloorTrafficCreate` model
- implement `POST /api/customers/{id}/floor-traffic`
- adjust OpenAI chat test mocks and inventory tests
- update fixtures for floor traffic tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687738d014c0832299eed7e5e5c9e5e0