### PR TITLE
Fix trailing slash behavior for API root routes

### DIFF
--- a/app/routers/accounts.py
+++ b/app/routers/accounts.py
@@ -7,6 +7,7 @@ router = APIRouter()
 
 
 @router.get("/", response_model=list[Account])
+@router.get("", response_model=list[Account], include_in_schema=False)
 def list_accounts():
     res = supabase.table("accounts").select("*").execute()
     return res.data
@@ -28,6 +29,7 @@ def get_account(account_id: int):
 
 
 @router.post("/", response_model=Account, status_code=status.HTTP_201_CREATED)
+@router.post("", response_model=Account, status_code=status.HTTP_201_CREATED, include_in_schema=False)
 def create_account(a: AccountCreate):
     try:
         res = supabase.table("accounts").insert(a.dict()).execute()

--- a/app/routers/activities.py
+++ b/app/routers/activities.py
@@ -39,6 +39,7 @@ def today_metrics():
     return counts
 
 @router.get("/", response_model=list[Activity])
+@router.get("", response_model=list[Activity], include_in_schema=False)
 def list_activities(customer_id: int = Query(None)):
     """List all activities, or filter by customer_id if provided."""
     try:
@@ -64,6 +65,7 @@ def get_activity(act_id: int):
     return res.data
 
 @router.post("/", response_model=Activity, status_code=status.HTTP_201_CREATED)
+@router.post("", response_model=Activity, status_code=status.HTTP_201_CREATED, include_in_schema=False)
 def create_activity(a: ActivityCreate):
     try:
         res = supabase.table("activities").insert(a.dict(exclude_none=True)).execute()

--- a/app/routers/contacts.py
+++ b/app/routers/contacts.py
@@ -6,6 +6,7 @@ from app.models import Contact, ContactCreate, ContactUpdate
 router = APIRouter()
 
 @router.get("/", response_model=list[Contact])
+@router.get("", response_model=list[Contact], include_in_schema=False)
 def list_contacts(
     q: str | None = Query(None, description="Search term for name"),
     email: str | None = Query(None, description="Filter by email"),
@@ -38,6 +39,7 @@ def get_contact(contact_id: int):
     return res.data
 
 @router.post("/", response_model=Contact, status_code=status.HTTP_201_CREATED)
+@router.post("", response_model=Contact, status_code=status.HTTP_201_CREATED, include_in_schema=False)
 def create_contact(c: ContactCreate):
     try:
         res = supabase.table("contacts").insert(c.dict()).execute()

--- a/app/routers/deals.py
+++ b/app/routers/deals.py
@@ -23,6 +23,7 @@ class Deal(DealCreate):
     id: int
 
 @router.get("/", response_model=list[Deal])
+@router.get("", response_model=list[Deal], include_in_schema=False)
 def list_deals(customer_id: Optional[int] = None):
     try:
         query = supabase.table("deals").select("*")
@@ -34,6 +35,7 @@ def list_deals(customer_id: Optional[int] = None):
         raise HTTPException(400, detail=e.message)
 
 @router.post("/", response_model=Deal)
+@router.post("", response_model=Deal, include_in_schema=False)
 def create_deal(deal: DealCreate):
     try:
         res = supabase.table("deals").insert(deal.dict()).execute()

--- a/app/routers/leads.py
+++ b/app/routers/leads.py
@@ -41,6 +41,7 @@ def get_lead(lead_id: int = Path(..., gt=0)):
     return res.data
 
 @router.post("/", response_model=Lead, status_code=201)
+@router.post("", response_model=Lead, status_code=201, include_in_schema=False)
 def create_lead(lead: LeadCreate):
     payload = lead.dict()
     try:

--- a/app/routers/opportunities.py
+++ b/app/routers/opportunities.py
@@ -6,6 +6,7 @@ from app.models import Opportunity, OpportunityCreate, OpportunityUpdate
 router = APIRouter()
 
 @router.get("/", response_model=list[Opportunity])
+@router.get("", response_model=list[Opportunity], include_in_schema=False)
 def list_opportunities():
     res = supabase.table("opportunities").select("*").execute()
     return res.data
@@ -22,6 +23,7 @@ def get_opportunity(opp_id: int):
     return res.data
 
 @router.post("/", response_model=Opportunity, status_code=status.HTTP_201_CREATED)
+@router.post("", response_model=Opportunity, status_code=status.HTTP_201_CREATED, include_in_schema=False)
 def create_opportunity(o: OpportunityCreate):
     try:
         res = supabase.table("opportunities").insert(o.dict()).execute()

--- a/app/routers/tasks.py
+++ b/app/routers/tasks.py
@@ -20,6 +20,7 @@ class Task(TaskCreate):
     id: int
 
 @router.get("/", response_model=list[Task])
+@router.get("", response_model=list[Task], include_in_schema=False)
 def list_tasks(customer_id: Optional[int] = None):
     try:
         query = supabase.table("tasks").select("*")
@@ -31,6 +32,7 @@ def list_tasks(customer_id: Optional[int] = None):
         raise HTTPException(400, detail=e.message)
 
 @router.post("/", response_model=Task)
+@router.post("", response_model=Task, include_in_schema=False)
 def create_task(task: TaskCreate):
     try:
         res = supabase.table("tasks").insert(task.dict()).execute()


### PR DESCRIPTION
## Summary
- make root GET/POST routes accept both with and without trailing slashes
- ensure leads router also has duplicate POST route

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877fc22299c832296a10f8b6d6c1f1f