### PR TITLE
Update datetime display

### DIFF
--- a/frontend/src/components/CustomerProfileCard.jsx
+++ b/frontend/src/components/CustomerProfileCard.jsx
@@ -1,6 +1,7 @@
 // frontend/src/components/CustomerProfileCard.jsx
 import React, { useState, useEffect } from "react";
 import { Phone, MessageCircle, Mail, Edit, Save, X } from "lucide-react";
+import { formatDateTime } from "../utils/formatDateTime";
 
 // --- Helper: Get initials for avatar ---
 function getInitials(name, fallback = "?") {
@@ -99,9 +100,7 @@ function CustomerLedger({ ledger }) {
         {ledger.map((entry, idx) => (
           <div key={entry.id || idx} className="border-b last:border-b-0 py-2">
             <div className="text-xs text-gray-600">
-              {entry.timestamp
-                ? new Date(entry.timestamp).toLocaleString()
-                : null}
+              {entry.timestamp ? formatDateTime(entry.timestamp) : null}
             </div>
             <div className="font-medium">{entry.type || "Note"}</div>
             <div className="text-gray-800">

--- a/frontend/src/components/FloorTrafficTable.jsx
+++ b/frontend/src/components/FloorTrafficTable.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { Phone, MessageCircle, Mail, Pencil } from 'lucide-react';
+import { formatTime } from '../utils/formatDateTime';
 export default function FloorTrafficTable({ rows, onEdit, onToggle }) {
   const [sortConfig, setSortConfig] = useState({ key: 'visit_time', direction: 'ascending' });
   const [acknowledged, setAcknowledged] = useState(new Set());
@@ -72,10 +73,10 @@ export default function FloorTrafficTable({ rows, onEdit, onToggle }) {
             data-label={h.label}
           >
             {h.key === 'visit_time' ? (
-              new Date(row[h.key]).toLocaleTimeString()
+              formatTime(row[h.key])
             ) : h.key === 'time_out' ? (
               row[h.key] ? (
-                new Date(row[h.key]).toLocaleTimeString()
+                formatTime(row[h.key])
               ) : (
                 <input
                   type="checkbox"

--- a/frontend/src/components/LedgerEntry.jsx
+++ b/frontend/src/components/LedgerEntry.jsx
@@ -1,8 +1,9 @@
 import React from 'react'
+import { formatDateTime } from '../utils/formatDateTime'
 
 export default function LedgerEntry({ entry }) {
   const { created_at, activity_type, subject, note, staff_name } = entry
-  const date = created_at ? new Date(created_at).toLocaleString() : ''
+  const date = formatDateTime(created_at)
   const summary = subject || note
   return (
     <div className="border-b py-2">

--- a/frontend/src/routes/CustomerCard.jsx
+++ b/frontend/src/routes/CustomerCard.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react'
 import { useParams, Link } from 'react-router-dom'
+import { formatDateTime } from '../utils/formatDateTime'
 import {
   Phone, MessageCircle, Mail, Edit, Save, X, Flame, User, Calendar, Star, MapPin,
   Sun, Moon, BadgeCheck, Upload, Cloud, Users, Globe, File, Map, CheckCircle, Plus
@@ -390,7 +391,7 @@ export default function CustomerCard({ userRole = "sales" }) {
                   {ledger.length ? ledger.map((entry, idx) =>
                     <motion.div key={entry.id} {...ANIM_PROPS} transition={{ delay: idx * 0.04 }}>
                       <div className="mb-2">
-                        <span className="text-xs font-semibold text-slate-600 dark:text-slate-300">{entry.created_at}</span>
+                        <span className="text-xs font-semibold text-slate-600 dark:text-slate-300">{formatDateTime(entry.created_at)}</span>
                         <div>{entry.note}</div>
                         <div className="text-xs text-slate-400">{entry.activity_type}</div>
                       </div>

--- a/frontend/src/routes/FloorLog.jsx
+++ b/frontend/src/routes/FloorLog.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { Users } from 'lucide-react';
+import { formatTime } from '../utils/formatDateTime';
 
 export default function FloorLog() {
   const [logs, setLogs] = useState([]);
@@ -102,10 +103,7 @@ export default function FloorLog() {
                       >
                         {['timeIn', 'timeOut'].includes(key)
                           ? log[key]
-                            ? new Date(log[key]).toLocaleTimeString([], {
-                                hour: '2-digit',
-                                minute: '2-digit',
-                              })
+                            ? formatTime(log[key])
                             : ''
                           : String(log[key] ?? '')}
                       </td>

--- a/frontend/src/utils/formatDateTime.js
+++ b/frontend/src/utils/formatDateTime.js
@@ -1,0 +1,24 @@
+export function formatDateTime(d) {
+  if (!d) return '';
+  const date = new Date(d);
+  const month = date.getMonth() + 1;
+  const day = date.getDate();
+  const year = String(date.getFullYear()).slice(-2);
+  let hours = date.getHours();
+  const minutes = String(date.getMinutes()).padStart(2, '0');
+  const ampm = hours >= 12 ? 'PM' : 'AM';
+  hours = hours % 12;
+  if (hours === 0) hours = 12;
+  return `${month}-${day}-${year} ${hours}:${minutes}${ampm}`;
+}
+
+export function formatTime(d) {
+  if (!d) return '';
+  const date = new Date(d);
+  let hours = date.getHours();
+  const minutes = String(date.getMinutes()).padStart(2, '0');
+  const ampm = hours >= 12 ? 'PM' : 'AM';
+  hours = hours % 12;
+  if (hours === 0) hours = 12;
+  return `${hours}:${minutes}${ampm}`;
+}


### PR DESCRIPTION
## Summary
- show ledger dates using new `formatDateTime` util
- render customer timeline and floor traffic times with the new format
- expose helper utilities `formatDateTime` and `formatTime`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878200db52c83228bccdf66b55f8769