### PR TITLE
Add unified new entry page

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -13,6 +13,7 @@ import CreateLeadForm         from "./components/CreateLeadForm";
 import FloorTrafficPage       from "./pages/FloorTrafficPage";
 import CreateFloorTrafficForm from "./components/CreateFloorTrafficForm";
 import Home                   from "./pages/Home";
+import NewEntryPage           from "./pages/NewEntryPage";
 import Logo                   from "./components/Logo";
 import ReconPage              from "./pages/ReconPage";
 import ChatGPTPrompt          from "./components/ChatGPTPrompt";
@@ -87,12 +88,11 @@ export default function App() {
   // Nav items as an array for clarity
   const navItems = [
     { to: "/",         label: "Home"             },
-    { to: "/leads/new",label: "New Lead"         },
     { to: "/users",    label: "Users"            },
     { to: "/inventory",label: "Inventory"        },
     { to: "/recon",    label: "Recon"            },
     {
-      to: "/floor-traffic/new",
+      to: "/new",
       label: (
         <span className="flex items-center">
           <Plus className="h-4 w-4" />
@@ -231,6 +231,7 @@ export default function App() {
           <Route path="/" element={<Home />} />
           <Route path="/leads" element={<LeadLog />} />
           <Route path="/leads/new" element={<CreateLeadForm />} />
+          <Route path="/new" element={<NewEntryPage />} />
           <Route path="/customers" element={<CustomersPage />} />
           <Route path="/customers/:id" element={<CustomerCard />} />
           <Route path="/users" element={<UsersPage />} />

--- a/frontend/src/pages/NewEntryPage.jsx
+++ b/frontend/src/pages/NewEntryPage.jsx
@@ -1,0 +1,27 @@
+import React, { useState } from 'react';
+import CreateLeadForm from '../components/CreateLeadForm';
+import CreateFloorTrafficForm from '../components/CreateFloorTrafficForm';
+
+export default function NewEntryPage() {
+  const [type, setType] = useState('floor');
+
+  return (
+    <div className="max-w-2xl mx-auto">
+      <div className="flex justify-center mb-4 gap-4">
+        <button
+          className={`px-3 py-1 rounded border ${type === 'floor' ? 'bg-electricblue text-white' : ''}`}
+          onClick={() => setType('floor')}
+        >
+          Floor Traffic
+        </button>
+        <button
+          className={`px-3 py-1 rounded border ${type === 'lead' ? 'bg-electricblue text-white' : ''}`}
+          onClick={() => setType('lead')}
+        >
+          New Lead
+        </button>
+      </div>
+      {type === 'floor' ? <CreateFloorTrafficForm /> : <CreateLeadForm />}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a NewEntryPage with a toggle between Floor Traffic and Lead forms
- remove standalone 'New Lead' link
- update `+` nav item to open `/new`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878258bf9888322afd7e2223743755c