### PR TITLE
Allow POST /api/users to accept `name`

### DIFF
--- a/app/routers/users.py
+++ b/app/routers/users.py
@@ -1,7 +1,7 @@
 # app/routers/users.py
 
 from fastapi import APIRouter, HTTPException, Path
-from pydantic import BaseModel, EmailStr
+from pydantic import BaseModel, EmailStr, Field, ConfigDict
 from postgrest.exceptions import APIError
 from app.db import supabase
 
@@ -10,8 +10,9 @@ router = APIRouter()
 # ─── Pydantic models ──────────────────────────────────────────────────────────────
 
 class UserCreate(BaseModel):
-    full_name: str
+    full_name: str = Field(..., alias="name")
     email: EmailStr
+    model_config = ConfigDict(populate_by_name=True)
 
 class User(UserCreate):
     id: int

--- a/app/routers/users.py
+++ b/app/routers/users.py
@@ -14,8 +14,11 @@ class UserCreate(BaseModel):
     email: EmailStr
     model_config = ConfigDict(populate_by_name=True)
 
-class User(UserCreate):
+class User(BaseModel):
     id: int
+    full_name: str = Field(..., alias="name")
+    email: EmailStr
+    model_config = ConfigDict(populate_by_name=True)
 
 # ─── Endpoints ────────────────────────────────────────────────────────────────────
 

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -1,0 +1,20 @@
+from fastapi.testclient import TestClient
+from unittest.mock import MagicMock, patch
+from app.main import app
+
+client = TestClient(app)
+
+
+def test_create_user_accepts_name_alias():
+    payload = {"name": "Alice", "email": "alice@example.com"}
+    inserted = {"id": 1, "name": "Alice", "email": "alice@example.com"}
+    mock_table = MagicMock()
+    mock_table.insert.return_value.execute.return_value = MagicMock(data=[inserted], error=None)
+    mock_supabase = MagicMock()
+    mock_supabase.table.return_value = mock_table
+
+    with patch("app.routers.users.supabase", mock_supabase):
+        response = client.post("/api/users/", json=payload)
+
+    assert response.status_code == 201
+    assert response.json() == inserted


### PR DESCRIPTION
## Summary
- handle `name` alias in user creation model
- add a regression test for POST /api/users

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68782608adf08322bdde62eec4fa1c05