### PR TITLE
Fix React import for version 19

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,5 +1,5 @@
 // src/App.jsx
-import React, { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef } from 'react';
 import { BrowserRouter as Router, Routes, Route, Link } from "react-router-dom";
 
 import LeadLog                from "./routes/LeadLog";

--- a/frontend/src/components/AIOverview.jsx
+++ b/frontend/src/components/AIOverview.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { ArrowUpRight, ArrowDownRight } from 'lucide-react';
 
 export default function AIOverview() {

--- a/frontend/src/components/AIQuoteOfTheDay.jsx
+++ b/frontend/src/components/AIQuoteOfTheDay.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 export default function AIQuoteOfTheDay() {
   return (
     <div className="italic text-gray-500 text-base text-center my-2">

--- a/frontend/src/components/AIWidget.jsx
+++ b/frontend/src/components/AIWidget.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from 'react';
 import { Bot, X } from "lucide-react";
 import ChatGPTPrompt from "./ChatGPTPrompt";
 

--- a/frontend/src/components/ActivityTimeline.jsx
+++ b/frontend/src/components/ActivityTimeline.jsx
@@ -1,5 +1,4 @@
 // frontend/src/components/ActivityTimeline.jsx
-import React from 'react'
 
 export default function ActivityTimeline() {
   return (

--- a/frontend/src/components/CreateFloorTrafficForm.jsx
+++ b/frontend/src/components/CreateFloorTrafficForm.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 export default function CreateFloorTrafficForm() {

--- a/frontend/src/components/CreateLeadForm.jsx
+++ b/frontend/src/components/CreateLeadForm.jsx
@@ -1,5 +1,5 @@
 // frontend/src/components/CreateLeadForm.jsx
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import toast from 'react-hot-toast';
 

--- a/frontend/src/components/CustomerProfileCard.jsx
+++ b/frontend/src/components/CustomerProfileCard.jsx
@@ -1,5 +1,5 @@
 // frontend/src/components/CustomerProfileCard.jsx
-import React, { useState, useEffect } from "react";
+import { useState, useEffect } from 'react';
 import { Phone, MessageCircle, Mail, Edit, Save, X } from "lucide-react";
 import { formatDateTime } from "../utils/formatDateTime";
 

--- a/frontend/src/components/CustomerSatisfaction.jsx
+++ b/frontend/src/components/CustomerSatisfaction.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Smile, Heart, X } from 'lucide-react';
 import { ResponsiveContainer, BarChart, Bar, Tooltip } from 'recharts';
 

--- a/frontend/src/components/FieldRow.jsx
+++ b/frontend/src/components/FieldRow.jsx
@@ -1,4 +1,3 @@
-import React from 'react'
 
 export default function FieldRow({ label, value, editMode, onChange, type = 'text' }) {
   if (editMode) {

--- a/frontend/src/components/FilterPanel.jsx
+++ b/frontend/src/components/FilterPanel.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react'
+import { useMemo } from 'react';
 
 export default function FilterPanel({ filters, onChange, options = {} }) {
   const handleInput = e => {

--- a/frontend/src/components/FloorTrafficModal.jsx
+++ b/frontend/src/components/FloorTrafficModal.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 
 export default function FloorTrafficModal({ isOpen, onClose, onSubmit, initialData }) {
   const [form, setForm] = useState({

--- a/frontend/src/components/FloorTrafficTable.jsx
+++ b/frontend/src/components/FloorTrafficTable.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { Phone, MessageCircle, Mail, Pencil } from 'lucide-react';
 import { formatTime } from '../utils/formatDateTime';
 export default function FloorTrafficTable({ rows, onEdit, onToggle }) {

--- a/frontend/src/components/Home.jsx
+++ b/frontend/src/components/Home.jsx
@@ -1,5 +1,4 @@
 // frontend/src/components/Home.jsx
-import React from 'react';
 import { Link } from 'react-router-dom';
 import Logo from './Logo';
 

--- a/frontend/src/components/InventoryCard.jsx
+++ b/frontend/src/components/InventoryCard.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from 'react';
 import {
   ChevronLeft,
   ChevronRight,

--- a/frontend/src/components/InventoryGrid.jsx
+++ b/frontend/src/components/InventoryGrid.jsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { motion as Motion, AnimatePresence } from 'framer-motion'
 import InventoryCard from './InventoryCard'
 

--- a/frontend/src/components/InventorySnapshot.jsx
+++ b/frontend/src/components/InventorySnapshot.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 
 export default function InventorySnapshot() {
   const [stats, setStats] = useState({

--- a/frontend/src/components/InventoryTable.jsx
+++ b/frontend/src/components/InventoryTable.jsx
@@ -1,4 +1,3 @@
-import React from 'react'
 
 export default function InventoryTable({ vehicles, onEdit, onToggle }) {
   return (

--- a/frontend/src/components/LeadPerformanceKPI.jsx
+++ b/frontend/src/components/LeadPerformanceKPI.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import {
   ResponsiveContainer,
   FunnelChart,

--- a/frontend/src/components/LedgerEntry.jsx
+++ b/frontend/src/components/LedgerEntry.jsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { formatDateTime } from '../utils/formatDateTime'
 
 export default function LedgerEntry({ entry }) {

--- a/frontend/src/components/Logo.jsx
+++ b/frontend/src/components/Logo.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 
 export default function Logo({ className = '' }) {
   return (

--- a/frontend/src/components/MarketingCampaignROI.jsx
+++ b/frontend/src/components/MarketingCampaignROI.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Megaphone } from 'lucide-react';
 import { ResponsiveContainer, BarChart, Bar, Tooltip } from 'recharts';
 

--- a/frontend/src/components/MonthlySummary.jsx
+++ b/frontend/src/components/MonthlySummary.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 
 export default function MonthlySummary() {
   const [summary, setSummary] = useState('');

--- a/frontend/src/components/NotificationsBar.jsx
+++ b/frontend/src/components/NotificationsBar.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { Bell } from "lucide-react";
 
 export default function NotificationsBar() {

--- a/frontend/src/components/Pagination.jsx
+++ b/frontend/src/components/Pagination.jsx
@@ -1,4 +1,3 @@
-import React from 'react'
 
 export default function Pagination({ currentPage, totalPages, onPageChange }) {
   if (totalPages <= 1) return null

--- a/frontend/src/components/ProductivityWidget.jsx
+++ b/frontend/src/components/ProductivityWidget.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { Lightbulb } from "lucide-react";
 
 export default function ProductivityWidget() {

--- a/frontend/src/components/QuickActionPanel.jsx
+++ b/frontend/src/components/QuickActionPanel.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { PlusCircle, Users, Car } from "lucide-react";
 import { Link } from "react-router-dom";
 

--- a/frontend/src/components/SalesPerformanceKPI.jsx
+++ b/frontend/src/components/SalesPerformanceKPI.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 
 export default function SalesPerformanceKPI() {
   const [stats, setStats] = useState({ demo: 0, worksheet: 0, offer: 0, sold: 0 });

--- a/frontend/src/components/SalesTeamActivity.jsx
+++ b/frontend/src/components/SalesTeamActivity.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { BarChart3 } from 'lucide-react';
 
 export default function SalesTeamActivity() {

--- a/frontend/src/components/ServiceDepartmentPerformance.jsx
+++ b/frontend/src/components/ServiceDepartmentPerformance.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import { Wrench } from 'lucide-react';
 import { ResponsiveContainer, BarChart, Bar, Tooltip } from 'recharts';
 

--- a/frontend/src/components/SmartSearchBar.jsx
+++ b/frontend/src/components/SmartSearchBar.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from 'react';
 import { Search } from "lucide-react";
 
 export default function SmartSearchBar() {

--- a/frontend/src/components/UserModal.jsx
+++ b/frontend/src/components/UserModal.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react'
+import { useState, useEffect } from 'react';
 
 export default function UserModal({ isOpen, onClose, onSubmit, initialData }) {
   const [form, setForm] = useState({

--- a/frontend/src/components/VehicleModal.jsx
+++ b/frontend/src/components/VehicleModal.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react'
+import { useState, useEffect } from 'react';
 
 export default function VehicleModal({ isOpen, onClose, onSubmit, initialData }) {
   const [form, setForm] = useState({

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { createRoot } from 'react-dom/client'
 import App from './App.jsx'
 import './index.css'

--- a/frontend/src/pages/FloorTrafficPage.jsx
+++ b/frontend/src/pages/FloorTrafficPage.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { createClient } from '@supabase/supabase-js';
 import FloorTrafficTable from '../components/FloorTrafficTable';
 import FloorTrafficModal from '../components/FloorTrafficModal';

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import { useEffect, useState, cloneElement } from 'react';
 import { Link } from "react-router-dom";
 import { motion as Motion } from "framer-motion";
 import { Sparkline } from "react-sparklines"; // Add sparklines for KPI cards
@@ -51,7 +51,7 @@ export default function Home() {
               style={{ marginBottom: "0.5rem" }}
             />
           )}
-          {React.cloneElement(children, { countUp: true })}
+          {cloneElement(children, { countUp: true })}
         </div>
       </Motion.div>
     </Link>

--- a/frontend/src/pages/NewEntryPage.jsx
+++ b/frontend/src/pages/NewEntryPage.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from 'react';
 import CreateLeadForm from "../components/CreateLeadForm";
 import CreateFloorTrafficForm from "../components/CreateFloorTrafficForm";
 

--- a/frontend/src/pages/ReconPage.tsx
+++ b/frontend/src/pages/ReconPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { fetchReconData, fetchReconSteps } from '../api/recon';
 import { LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer, BarChart, Bar } from 'recharts';
 

--- a/frontend/src/routes/CustomerCard.jsx
+++ b/frontend/src/routes/CustomerCard.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import { useEffect, useState } from 'react';
 import { useParams, Link } from 'react-router-dom'
 import { formatDateTime } from '../utils/formatDateTime'
 import {

--- a/frontend/src/routes/CustomersPage.jsx
+++ b/frontend/src/routes/CustomersPage.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom'
 import { Phone, MessageCircle, Mail } from 'lucide-react'
 

--- a/frontend/src/routes/FloorLog.jsx
+++ b/frontend/src/routes/FloorLog.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Users } from 'lucide-react';
 import { formatTime } from '../utils/formatDateTime';
 

--- a/frontend/src/routes/Home.jsx
+++ b/frontend/src/routes/Home.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Link } from 'react-router-dom';
 import SalesPerformanceKPI from '../components/SalesPerformanceKPI';
 import LeadPerformanceKPI from '../components/LeadPerformanceKPI';

--- a/frontend/src/routes/InventoryPage.jsx
+++ b/frontend/src/routes/InventoryPage.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo } from 'react'
+import { useState, useEffect, useMemo } from 'react';
 import toast from 'react-hot-toast'
 import FilterPanel from '../components/FilterPanel'
 import Pagination from '../components/Pagination'

--- a/frontend/src/routes/KPIDetailPage.jsx
+++ b/frontend/src/routes/KPIDetailPage.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { useParams } from 'react-router-dom';
 import SalesPerformanceKPI from '../components/SalesPerformanceKPI';
 import LeadPerformanceKPI from '../components/LeadPerformanceKPI';

--- a/frontend/src/routes/Users.jsx
+++ b/frontend/src/routes/Users.jsx
@@ -1,5 +1,5 @@
 // frontend/src/routes/Users.jsx
-import React, { useEffect, useState } from 'react'
+import { useEffect, useState } from 'react';
 
 export default function Users() {
   const [users, setUsers] = useState([])

--- a/frontend/src/routes/UsersPage.jsx
+++ b/frontend/src/routes/UsersPage.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import { useEffect, useState } from 'react';
 import toast from 'react-hot-toast'
 import UserModal from '../components/UserModal'
 import Pagination from '../components/Pagination'


### PR DESCRIPTION
## Summary
- drop `React` default import across the frontend
- update Home page to import `cloneElement`

## Testing
- `npm run build` in `frontend`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68786ef05dc48322b5f956d4b0a46756