### PR TITLE
Add email composer modal

### DIFF
--- a/frontend/src/components/CustomerProfileCard.jsx
+++ b/frontend/src/components/CustomerProfileCard.jsx
@@ -2,6 +2,7 @@
 import { useState, useEffect } from 'react';
 import { Phone, MessageCircle, Mail, Edit, Save, X } from "lucide-react";
 import { formatDateTime } from "../utils/formatDateTime";
+import EmailModal from "./EmailModal";
 
 // --- Helper: Get initials for avatar ---
 function getInitials(name, fallback = "?") {
@@ -121,6 +122,7 @@ export default function CustomerProfileCard({ customer, ledger = [], onSave }) {
   const [editMode, setEditMode] = useState(false);
   const [form, setForm] = useState(customer);
   const [activeTab, setActiveTab] = useState("Details");
+  const [showEmailModal, setShowEmailModal] = useState(false);
   const API_BASE = import.meta.env.VITE_API_BASE_URL || '/api'
   const CURRENT_USER_ID = 1
 
@@ -132,7 +134,9 @@ export default function CustomerProfileCard({ customer, ledger = [], onSave }) {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(payload)
       })
-    } catch {}
+    } catch (err) {
+      console.error('Failed to log activity', err)
+    }
   }
 
   // Simulated tags: you might fetch or compute these
@@ -186,7 +190,7 @@ export default function CustomerProfileCard({ customer, ledger = [], onSave }) {
         {email && (
           <button
             className="rounded-full p-2 hover:bg-blue-100"
-            onClick={() => { logActivity('email', '', 'Email'); window.location.href = `mailto:${email}` }}
+            onClick={() => { logActivity('email', '', 'Email'); setShowEmailModal(true); }}
             title="Email"
           >
             <Mail className="w-4 h-4" />
@@ -197,6 +201,7 @@ export default function CustomerProfileCard({ customer, ledger = [], onSave }) {
   }
 
   return (
+    <>
     <div className="rounded-lg shadow bg-white p-6 space-y-4 max-w-3xl mx-auto mt-8">
       {/* --- Top: Avatar, Name, Tags, Actions --- */}
       <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between">
@@ -294,5 +299,11 @@ export default function CustomerProfileCard({ customer, ledger = [], onSave }) {
         )}
       </div>
     </div>
+    <EmailModal
+      isOpen={showEmailModal}
+      onClose={() => setShowEmailModal(false)}
+      customer={customer}
+    />
+    </>
   );
 }

--- a/frontend/src/components/EmailModal.jsx
+++ b/frontend/src/components/EmailModal.jsx
@@ -1,0 +1,78 @@
+import { useState, useRef } from 'react';
+
+export default function EmailModal({ isOpen, onClose, customer }) {
+  const [toEmail, setToEmail] = useState(customer?.email || '');
+  const [subject, setSubject] = useState('');
+  const [bodyHtml, setBodyHtml] = useState('');
+  const [status, setStatus] = useState('');
+  const editorRef = useRef(null);
+
+  const API_BASE = import.meta.env.VITE_API_BASE_URL || '/api';
+
+  const sendEmail = async () => {
+    try {
+      const res = await fetch(`${API_BASE}/emails/send`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          to_email: toEmail,
+          subject,
+          body: bodyHtml,
+          customer_id: customer?.id,
+        }),
+      });
+      if (res.ok) setStatus('Sent!');
+      else setStatus('Error sending email.');
+    } catch {
+      setStatus('Error sending email.');
+    }
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 overflow-y-auto">
+      <div className="bg-white dark:bg-gray-800 p-6 rounded w-full max-w-xl space-y-4">
+        <h3 className="text-lg font-semibold">Compose Email</h3>
+        <input
+          value={toEmail}
+          onChange={e => setToEmail(e.target.value)}
+          placeholder="To"
+          className="w-full border rounded px-3 py-2"
+        />
+        <input
+          value={subject}
+          onChange={e => setSubject(e.target.value)}
+          placeholder="Subject"
+          className="w-full border rounded px-3 py-2"
+        />
+        <div className="flex gap-2 text-sm">
+          <button type="button" onClick={() => document.execCommand('bold')} className="px-2 py-1 border rounded">
+            <strong>B</strong>
+          </button>
+          <button type="button" onClick={() => document.execCommand('italic')} className="px-2 py-1 border rounded italic">
+            I
+          </button>
+          <button type="button" onClick={() => document.execCommand('underline')} className="px-2 py-1 border rounded underline">
+            U
+          </button>
+        </div>
+        <div
+          ref={editorRef}
+          contentEditable
+          onInput={e => setBodyHtml(e.currentTarget.innerHTML)}
+          className="border rounded px-3 py-2 min-h-[150px] bg-white text-black dark:bg-gray-700 dark:text-white"
+        />
+        <div className="flex justify-end gap-2">
+          <button type="button" onClick={onClose} className="px-3 py-2 border rounded">
+            Cancel
+          </button>
+          <button type="button" onClick={sendEmail} className="px-3 py-2 bg-electricblue text-white rounded">
+            Send Email
+          </button>
+        </div>
+        {status && <div className="text-sm">{status}</div>}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/QuickActionPanel.jsx
+++ b/frontend/src/components/QuickActionPanel.jsx
@@ -10,12 +10,19 @@ export default function QuickActionPanel() {
 
   return (
     <div className="flex gap-2 bg-white dark:bg-gray-800 p-3 rounded-lg shadow overflow-x-auto">
-      {actions.map(({ to, icon: Icon, label }) => (
-        <Link key={to} to={to} className="flex items-center gap-1 px-2 py-1 text-sm text-electricblue hover:underline whitespace-nowrap">
-          <Icon className="w-4 h-4" />
-          {label}
-        </Link>
-      ))}
+      {actions.map(({ to, icon, label }) => {
+        const IconComponent = icon;
+        return (
+          <Link
+            key={to}
+            to={to}
+            className="flex items-center gap-1 px-2 py-1 text-sm text-electricblue hover:underline whitespace-nowrap"
+          >
+            <IconComponent className="w-4 h-4" />
+            {label}
+          </Link>
+        );
+      })}
     </div>
   );
 }

--- a/frontend/src/routes/CustomerCard.jsx
+++ b/frontend/src/routes/CustomerCard.jsx
@@ -5,7 +5,7 @@ import {
   Phone, MessageCircle, Mail, Edit, Save, X, Flame, User, Calendar, Star, MapPin,
   Sun, Moon, BadgeCheck, Upload, Cloud, Users, Globe, File, Map, CheckCircle, Plus
 } from 'lucide-react'
-import { motion, AnimatePresence } from 'framer-motion'
+import { motion as Motion, AnimatePresence } from 'framer-motion'
 import clsx from 'clsx'
 
 function getInitials(name = '') {
@@ -69,7 +69,9 @@ export default function CustomerCard({ userRole = "sales" }) {
       })
       fetch(`${API_BASE}/activities?customer_id=${id}`)
         .then(r => r.json()).then(setLedger)
-    } catch {}
+    } catch (err) {
+      console.error('Failed to log activity', err)
+    }
   }
 
   useEffect(() => {
@@ -135,7 +137,9 @@ export default function CustomerCard({ userRole = "sales" }) {
       setCustomer(data)
       setEdited(data)
       setEditMode(false)
-    } catch (err) { alert('Failed to save') }
+    } catch (err) {
+      console.error('Failed to save', err)
+    }
   }
   const handleCancel = () => { setEdited(customer); setEditMode(false) }
 
@@ -266,9 +270,9 @@ export default function CustomerCard({ userRole = "sales" }) {
             ? <img src={customer.avatar_url} alt="avatar" className="rounded-full w-16 h-16 object-cover" />
             : getInitials(customer.full_name || customer.name || customer.first_name || "U")}
           {inMarket &&
-            <motion.span {...ANIM_PROPS}
+            <Motion.span {...ANIM_PROPS}
               className="absolute -top-1 -right-1 bg-red-500 text-white text-xs rounded-full px-2 py-1 shadow font-bold animate-pulse"
-            >IN MARKET</motion.span>}
+            >IN MARKET</Motion.span>}
           {isOnline &&
             <span className="absolute -bottom-1 -right-1 w-3 h-3 bg-green-400 border-2 border-white rounded-full shadow"></span>}
         </div>
@@ -360,42 +364,45 @@ export default function CustomerCard({ userRole = "sales" }) {
       <div>
         <AnimatePresence mode="wait">
           {tab === 'profile' && (
-            <motion.div key="profile" {...ANIM_PROPS}>
+            <Motion.div key="profile" {...ANIM_PROPS}>
               <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                {profileFields.map(({ key, label, icon: Icon }) => (
-                  <div key={key} className="flex items-center gap-2 border-b border-slate-100 dark:border-slate-700 py-2">
-                    <Icon className="w-5 h-5 text-blue-500" />
-                    <span className="font-medium w-28">{label}</span>
-                    {editMode ? (
-                      <input
-                        className="bg-slate-100 dark:bg-slate-800 border rounded px-2 py-1 flex-1"
-                        type={key === 'email' ? 'email' : key === 'phone' ? 'tel' : 'text'}
-                        value={edited?.[key] ?? ''}
-                        onChange={e => setEdited({ ...edited, [key]: e.target.value })}
-                        placeholder={label}
-                      />
-                    ) : (
-                      <span className="flex-1">{customer[key] ?? <span className="text-slate-400 italic">Not set</span>}</span>
-                    )}
-                  </div>
-                ))}
+                {profileFields.map(({ key, label, icon }) => {
+                  const IconComp = icon;
+                  return (
+                    <div key={key} className="flex items-center gap-2 border-b border-slate-100 dark:border-slate-700 py-2">
+                      <IconComp className="w-5 h-5 text-blue-500" />
+                      <span className="font-medium w-28">{label}</span>
+                      {editMode ? (
+                        <input
+                          className="bg-slate-100 dark:bg-slate-800 border rounded px-2 py-1 flex-1"
+                          type={key === 'email' ? 'email' : key === 'phone' ? 'tel' : 'text'}
+                          value={edited?.[key] ?? ''}
+                          onChange={e => setEdited({ ...edited, [key]: e.target.value })}
+                          placeholder={label}
+                        />
+                      ) : (
+                        <span className="flex-1">{customer[key] ?? <span className="text-slate-400 italic">Not set</span>}</span>
+                      )}
+                    </div>
+                  );
+                })}
               </div>
-            </motion.div>
+            </Motion.div>
           )}
 
           {tab === 'ledger' && (
-            <motion.div key="ledger" {...ANIM_PROPS}>
+            <Motion.div key="ledger" {...ANIM_PROPS}>
               <h3 className="font-bold mb-2">Activity Timeline</h3>
               <div className="max-h-64 overflow-y-auto bg-slate-50 dark:bg-slate-800 rounded p-2 border">
                 <AnimatePresence>
                   {ledger.length ? ledger.map((entry, idx) =>
-                    <motion.div key={entry.id} {...ANIM_PROPS} transition={{ delay: idx * 0.04 }}>
+                    <Motion.div key={entry.id} {...ANIM_PROPS} transition={{ delay: idx * 0.04 }}>
                       <div className="mb-2">
                         <span className="text-xs font-semibold text-slate-600 dark:text-slate-300">{formatDateTime(entry.created_at)}</span>
                         <div>{entry.note}</div>
                         <div className="text-xs text-slate-400">{entry.activity_type}</div>
                       </div>
-                    </motion.div>
+                    </Motion.div>
                   ) : <div className="text-slate-400">No activity yet.</div>}
                 </AnimatePresence>
               </div>
@@ -403,20 +410,20 @@ export default function CustomerCard({ userRole = "sales" }) {
                 <textarea className="flex-1 border rounded p-2 bg-white dark:bg-slate-900" rows={2} placeholder="Add note..." value={note} onChange={e => setNote(e.target.value)} />
                 <button className="px-3 py-1 bg-blue-700 text-white rounded" onClick={handleAddNote}>Add</button>
               </div>
-            </motion.div>
+            </Motion.div>
           )}
 
           {tab === 'deals' && (
-            <motion.div key="deals" {...ANIM_PROPS}>
+            <Motion.div key="deals" {...ANIM_PROPS}>
               <div className="text-slate-500 text-center py-8 text-lg">
                 <Star className="mx-auto mb-2 w-6 h-6" />
                 Deals module coming soon!
               </div>
-            </motion.div>
+            </Motion.div>
           )}
 
           {tab === 'ai' && (
-            <motion.div key="ai" {...ANIM_PROPS}>
+            <Motion.div key="ai" {...ANIM_PROPS}>
               <h3 className="font-bold mb-2">AI Insights</h3>
               {aiInfo?.summary && <div className="mb-2">{aiInfo.summary}</div>}
               {aiInfo?.next_steps?.length > 0 && (
@@ -448,11 +455,11 @@ export default function CustomerCard({ userRole = "sales" }) {
                   </button>
                 </div>
               )}
-            </motion.div>
+            </Motion.div>
           )}
 
           {tab === 'tasks' && (
-            <motion.div key="tasks" {...ANIM_PROPS}>
+            <Motion.div key="tasks" {...ANIM_PROPS}>
               <div className="flex items-center mb-3">
                 <h3 className="font-bold flex-1">Tasks & Reminders</h3>
                 <button className="bg-blue-700 text-white px-2 py-1 rounded flex items-center gap-1" onClick={() => setShowTaskModal(true)}><Plus className="w-4 h-4" /> New Task</button>
@@ -468,11 +475,11 @@ export default function CustomerCard({ userRole = "sales" }) {
                   </div>
                 )) : <div className="text-slate-400 py-8 text-center">No tasks yet.</div>}
               </div>
-            </motion.div>
+            </Motion.div>
           )}
 
           {tab === 'appointments' && (
-            <motion.div key="appointments" {...ANIM_PROPS}>
+            <Motion.div key="appointments" {...ANIM_PROPS}>
               <div className="flex items-center mb-3">
                 <h3 className="font-bold flex-1">Appointments</h3>
                 <button className="bg-blue-700 text-white px-2 py-1 rounded flex items-center gap-1" onClick={() => setShowApptModal(true)}><Plus className="w-4 h-4" /> Book Appt</button>
@@ -485,11 +492,11 @@ export default function CustomerCard({ userRole = "sales" }) {
                   </div>
                 )) : <div className="text-slate-400 py-8 text-center">No appointments yet.</div>}
               </div>
-            </motion.div>
+            </Motion.div>
           )}
 
           {tab === 'docs' && (
-            <motion.div key="docs" {...ANIM_PROPS}>
+            <Motion.div key="docs" {...ANIM_PROPS}>
               <div className="mb-3 flex items-center gap-3">
                 <File className="w-5 h-5" />
                 <h3 className="font-bold">Documents & Uploads</h3>
@@ -510,11 +517,11 @@ export default function CustomerCard({ userRole = "sales" }) {
                 )}
                 {!files.length && <div className="col-span-2 text-slate-400">No documents uploaded yet.</div>}
               </div>
-            </motion.div>
+            </Motion.div>
           )}
 
           {tab === 'map' && (
-            <motion.div key="map" {...ANIM_PROPS}>
+            <Motion.div key="map" {...ANIM_PROPS}>
               <div className="flex items-center gap-2 mb-3">
                 <Map className="w-5 h-5" />
                 <h3 className="font-bold">Customer Location</h3>
@@ -529,7 +536,7 @@ export default function CustomerCard({ userRole = "sales" }) {
                   title="Customer Location Map"
                 />
               ) : <div className="text-slate-400">No address provided.</div>}
-            </motion.div>
+            </Motion.div>
           )}
         </AnimatePresence>
       </div>


### PR DESCRIPTION
## Summary
- use custom contenteditable field instead of ReactQuill
- fix lint warnings in QuickActionPanel and CustomerCard
- log errors when activity logging fails
- integrate EmailModal in CustomerProfileCard without external dependency

## Testing
- `npm run lint`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6879392bbcd083228e3d915241e9c273