### PR TITLE
Implement CRM-wide search feature

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -20,6 +20,7 @@ from app.routers.analytics      import router as analytics_router
 from app.routers.tasks          import router as tasks_router
 from app.routers.appointments   import router as appointments_router
 from app.routers.deals          import router as deals_router
+from app.routers.search         import router as search_router
 from app.openai_router          import router as ai_router       # ← NEW
 
 # ── App init ────────────────────────────────────────────────────────────────
@@ -88,6 +89,7 @@ app.include_router(analytics_router,     prefix=f"{api_prefix}/analytics",    ta
 app.include_router(tasks_router,         prefix=f"{api_prefix}/tasks",        tags=["tasks"])
 app.include_router(appointments_router,  prefix=f"{api_prefix}/appointments", tags=["appointments"])
 app.include_router(deals_router,         prefix=f"{api_prefix}/deals",        tags=["deals"])
+app.include_router(search_router,        prefix=f"{api_prefix}",              tags=["search"])
 
 # NEW: AI assistant routes (POST /api/ai/ask, GET /api/ai/ask-stream)
 app.include_router(ai_router,            prefix=f"{api_prefix}",              tags=["ai"])

--- a/app/routers/search.py
+++ b/app/routers/search.py
@@ -1,0 +1,41 @@
+from fastapi import APIRouter, HTTPException, Query
+from postgrest.exceptions import APIError
+from app.db import supabase
+
+router = APIRouter()
+
+@router.get("/search")
+def global_search(q: str = Query(..., min_length=1), limit: int = 5):
+    """Search customers and inventory for the given text."""
+    q = q.strip()
+    if not q:
+        return {"customers": [], "inventory": []}
+
+    try:
+        customer_query = (
+            supabase
+            .table("customers")
+            .select("id,name,email,phone")
+            .or_(f"name.ilike.%{q}%,email.ilike.%{q}%,phone.ilike.%{q}%")
+            .limit(limit)
+        )
+        customers = customer_query.execute().data or []
+    except APIError as e:
+        raise HTTPException(status_code=400, detail=e.message)
+
+    try:
+        inventory_query = (
+            supabase
+            .table("inventory")
+            .select("id,make,model,vin,stocknumber,year")
+            .or_(
+                f"make.ilike.%{q}%,model.ilike.%{q}%,vin.ilike.%{q}%,stocknumber.ilike.%{q}%"
+            )
+            .limit(limit)
+        )
+        inventory = inventory_query.execute().data or []
+    except APIError as e:
+        raise HTTPException(status_code=400, detail=e.message)
+
+    return {"customers": customers, "inventory": inventory}
+

--- a/frontend/src/components/SmartSearchBar.jsx
+++ b/frontend/src/components/SmartSearchBar.jsx
@@ -1,26 +1,84 @@
-import { useState } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { Search } from "lucide-react";
+import { Link } from "react-router-dom";
 
 export default function SmartSearchBar() {
-  const [query, setQuery] = useState("");
+  const API_BASE = import.meta.env.VITE_API_BASE_URL || '/api';
+  const [query, setQuery] = useState('');
+  const [results, setResults] = useState({ customers: [], inventory: [] });
+  const [open, setOpen] = useState(false);
+  const timer = useRef();
 
-  const handleSubmit = (e) => {
-    e.preventDefault();
-    if (!query.trim()) return;
-    // Placeholder for real search logic
-    console.log("Searching for", query);
+  useEffect(() => {
+    if (!query.trim()) {
+      setResults({ customers: [], inventory: [] });
+      return;
+    }
+    clearTimeout(timer.current);
+    timer.current = setTimeout(() => {
+      fetch(`${API_BASE}/search?q=${encodeURIComponent(query.trim())}`)
+        .then(r => (r.ok ? r.json() : Promise.reject()))
+        .then(data => setResults(data))
+        .catch(() => setResults({ customers: [], inventory: [] }));
+    }, 300);
+  }, [query, API_BASE]);
+
+  const handleFocus = () => setOpen(true);
+  const handleBlur = () => setTimeout(() => setOpen(false), 150);
+
+  const clear = () => {
+    setQuery('');
+    setResults({ customers: [], inventory: [] });
+    setOpen(false);
   };
 
   return (
-    <form onSubmit={handleSubmit} className="flex items-center bg-white dark:bg-gray-800 px-3 py-2 rounded-lg shadow w-full max-w-sm">
-      <Search className="w-4 h-4 text-electricblue" />
-      <input
-        type="text"
-        value={query}
-        onChange={(e) => setQuery(e.target.value)}
-        placeholder="Search..."
-        className="ml-2 flex-grow bg-transparent focus:outline-none text-sm"
-      />
-    </form>
+    <div className="relative w-full max-w-sm">
+      <form onSubmit={e => e.preventDefault()} className="flex items-center bg-white dark:bg-gray-800 px-3 py-2 rounded-lg shadow w-full">
+        <Search className="w-4 h-4 text-electricblue" />
+        <input
+          type="text"
+          value={query}
+          onChange={e => setQuery(e.target.value)}
+          onFocus={handleFocus}
+          onBlur={handleBlur}
+          placeholder="Search..."
+          className="ml-2 flex-grow bg-transparent focus:outline-none text-sm"
+        />
+      </form>
+      {open && (results.customers.length || results.inventory.length) ? (
+        <div className="absolute z-10 mt-1 w-full bg-white dark:bg-gray-800 border rounded shadow max-h-60 overflow-y-auto text-sm">
+          {results.customers.length > 0 && (
+            <div className="px-2 py-1 font-semibold text-gray-700 dark:text-gray-200 border-b">Customers</div>
+          )}
+          {results.customers.map(c => (
+            <Link
+              key={`c-${c.id}`}
+              to={`/customers/${c.id}`}
+              onMouseDown={e => e.preventDefault()}
+              onClick={clear}
+              className="block px-2 py-1 hover:bg-gray-100 dark:hover:bg-gray-700"
+            >
+              {c.name}
+            </Link>
+          ))}
+          {results.inventory.length > 0 && (
+            <div className="px-2 py-1 font-semibold text-gray-700 dark:text-gray-200 border-t">Inventory</div>
+          )}
+          {results.inventory.map(v => (
+            <Link
+              key={`v-${v.id}`}
+              to={`/inventory?q=${encodeURIComponent(v.vin || v.stocknumber || '')}`}
+              onMouseDown={e => e.preventDefault()}
+              onClick={clear}
+              className="block px-2 py-1 hover:bg-gray-100 dark:hover:bg-gray-700"
+            >
+              {`${v.year || ''} ${v.make || ''} ${v.model || ''}`.trim() || v.vin || v.stocknumber}
+            </Link>
+          ))}
+        </div>
+      ) : null}
+    </div>
   );
 }
+

--- a/frontend/src/routes/InventoryPage.jsx
+++ b/frontend/src/routes/InventoryPage.jsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useMemo } from 'react';
+import { useLocation } from 'react-router-dom';
 import toast from 'react-hot-toast'
 import FilterPanel from '../components/FilterPanel'
 import Pagination from '../components/Pagination'
@@ -8,10 +9,14 @@ import VehicleModal from '../components/VehicleModal'
 
 export default function InventoryPage() {
   const API_BASE = import.meta.env.VITE_API_BASE_URL || '/api'
+  const location = useLocation()
+
+  const params = new URLSearchParams(location.search)
+  const initialSearch = params.get('q') || ''
 
   const [vehicles, setVehicles] = useState([])
   const [filtered, setFiltered] = useState([])
-  const [search, setSearch] = useState('')
+  const [search, setSearch] = useState(initialSearch)
   const [debounced, setDebounced] = useState('')
   const [filters, setFilters] = useState({
     make: [],
@@ -34,6 +39,12 @@ export default function InventoryPage() {
   const [error, setError] = useState('')
   const [modalOpen, setModalOpen] = useState(false)
   const [editing, setEditing] = useState(null)
+
+  // Update search when URL query changes
+  useEffect(() => {
+    const p = new URLSearchParams(location.search)
+    setSearch(p.get('q') || '')
+  }, [location.search])
 
   const makeOptions = useMemo(
     () => Array.from(new Set(vehicles.map(v => v.make).filter(Boolean))).sort(),

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,0 +1,36 @@
+from unittest.mock import MagicMock, patch
+from app.main import app
+from fastapi.testclient import TestClient
+
+client = TestClient(app)
+
+
+def test_global_search():
+    cust_sample = [{"id": 1, "name": "Alice"}]
+    inv_sample = [{"id": 2, "make": "Ford"}]
+
+    cust_query = MagicMock()
+    cust_query.or_.return_value.limit.return_value.execute.return_value = MagicMock(data=cust_sample, error=None)
+
+    inv_query = MagicMock()
+    inv_query.or_.return_value.limit.return_value.execute.return_value = MagicMock(data=inv_sample, error=None)
+
+    def table_side(name):
+        tbl = MagicMock()
+        if name == "customers":
+            tbl.select.return_value = cust_query
+        elif name == "inventory":
+            tbl.select.return_value = inv_query
+        return tbl
+
+    mock_supabase = MagicMock()
+    mock_supabase.table.side_effect = table_side
+
+    with patch("app.routers.search.supabase", mock_supabase):
+        res = client.get("/api/search?q=al")
+
+    assert res.status_code == 200
+    assert res.json() == {"customers": cust_sample, "inventory": inv_sample}
+    cust_query.or_.assert_called()
+    inv_query.or_.assert_called()
+


### PR DESCRIPTION
## Summary
- add new `/api/search` endpoint combining customers and inventory
- surface search results in SmartSearchBar component
- allow Inventory page to read `q` param from URL
- include test coverage for the search endpoint

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68797a9c9c648322ada0cbe40ddf2c76