### PR TITLE
Add AI inventory review

### DIFF
--- a/frontend/src/components/AIInventoryReview.jsx
+++ b/frontend/src/components/AIInventoryReview.jsx
@@ -1,0 +1,51 @@
+import { useEffect, useState } from 'react';
+
+export default function AIInventoryReview({ vehicleId, open, onClose, radius = 200 }) {
+  const [data, setData] = useState(null);
+  const [loading, setLoading] = useState(false);
+  const API_BASE = import.meta.env.VITE_API_BASE_URL || '/api';
+
+  useEffect(() => {
+    if (!open) return;
+    const fetchData = async () => {
+      setLoading(true);
+      try {
+        const res = await fetch(`${API_BASE}/ai/inventory/${vehicleId}/review`);
+        const json = await res.json();
+        setData(json);
+      } catch {
+        setData({ analysis: 'Error loading review' });
+      }
+      setLoading(false);
+    };
+    fetchData();
+  }, [open, vehicleId]);
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50" role="dialog" aria-modal="true">
+      <div className="bg-white dark:bg-gray-800 p-4 rounded shadow max-w-md w-full">
+        {loading ? (
+          <div className="py-10 text-center">Loading…</div>
+        ) : (
+          <>
+            <pre className="whitespace-pre-wrap text-sm">{data?.analysis}</pre>
+            <div className="mt-3 text-xs space-y-1">
+              {data && (
+                <>
+                  <div>Avg price: {data.market_avg?.toLocaleString()}</div>
+                  <div>Range: {data.market_low?.toLocaleString()}–{data.market_high?.toLocaleString()}</div>
+                  <div>Listings in {radius} mi: {data.num_available}</div>
+                </>
+              )}
+            </div>
+          </>
+        )}
+        <div className="text-right mt-4">
+          <button onClick={onClose} className="px-3 py-2 bg-electricblue text-white rounded">Close</button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/InventoryCard.jsx
+++ b/frontend/src/components/InventoryCard.jsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import AIInventoryReview from './AIInventoryReview';
 import {
   ChevronLeft,
   ChevronRight,
@@ -63,6 +64,7 @@ export default function InventoryCard({ vehicle, onEdit, onToggle }) {
 
   const [current, setCurrent] = useState(0);
   const [open, setOpen] = useState(false);
+  const [reviewOpen, setReviewOpen] = useState(false);
   const prevImage = () =>
     setCurrent((i) => (i === 0 ? displayImages.length - 1 : i - 1));
   const nextImage = () =>
@@ -200,6 +202,12 @@ export default function InventoryCard({ vehicle, onEdit, onToggle }) {
               Edit
             </button>
           )}
+          <button
+            onClick={() => setReviewOpen(true)}
+            className="px-3 py-1 bg-purple-600 text-white text-sm rounded-md hover:bg-purple-700 transition"
+          >
+            AI Review
+          </button>
           {onToggle && (
             <button
               onClick={() => onToggle(vehicle)}
@@ -237,6 +245,12 @@ export default function InventoryCard({ vehicle, onEdit, onToggle }) {
           </div>
         </div>
       )}
+      <AIInventoryReview
+        vehicleId={vehicle.id}
+        open={reviewOpen}
+        onClose={() => setReviewOpen(false)}
+      />
     </div>
   );
 }
+

--- a/tests/test_ai.py
+++ b/tests/test_ai.py
@@ -38,3 +38,53 @@ def test_ai_ask_inventory_keyword():
     mock_supabase.table.assert_called_with("ai_inventory_context")
     mock_table.select.assert_called_with("*")
     mock_openai.chat.completions.create.assert_called_once()
+
+
+def test_inventory_ai_review():
+    vehicle = {
+        "id": 1,
+        "year": 2024,
+        "make": "Ford",
+        "model": "F-150",
+        "trim": "XL",
+        "sellingprice": 30000,
+        "mileage": 10000,
+    }
+    exec_result = MagicMock(data=vehicle, error=None)
+    mock_chain = MagicMock()
+    mock_chain.eq.return_value = mock_chain
+    mock_chain.maybe_single.return_value = mock_chain
+    mock_chain.execute.return_value = exec_result
+
+    mock_table = MagicMock()
+    mock_table.select.return_value = mock_chain
+
+    mock_supabase = MagicMock()
+    mock_supabase.table.return_value = mock_table
+
+    comps_result = {
+        "comps": [
+            {"price": 31000},
+            {"price": 32000},
+        ],
+        "market_avg": 31500,
+        "market_low": 30000,
+        "market_high": 33000,
+    }
+
+    mock_resp = MagicMock(
+        choices=[MagicMock(message=MagicMock(content="Looks good"))]
+    )
+    mock_openai = MagicMock()
+    mock_openai.chat.completions.create = AsyncMock(return_value=mock_resp)
+
+    with patch("app.openai_router.supabase", mock_supabase), \
+         patch("app.openai_router.aggregate_comps", return_value=comps_result), \
+         patch("app.openai_router.get_openai_client", return_value=mock_openai):
+        response = client.get("/api/ai/inventory/1/review")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["num_available"] == 2
+    assert data["market_avg"] == 31500
+    assert data["analysis"] == "Looks good"


### PR DESCRIPTION
## Summary
- add AI review endpoint for inventory items
- show AI review modal from InventoryCard
- implement frontend component for AI review
- test new functionality

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879a3927b308322ac5dcdded1ce09a0