### PR TITLE
Implement appraisal models and router

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -22,6 +22,7 @@ from app.routers.appointments   import router as appointments_router
 from app.routers.deals          import router as deals_router
 from app.routers.comps          import router as comps_router    # ← NEW
 from app.routers.search         import router as search_router
+from app.routers.appraisals     import router as appraisals_router
 from app.openai_router          import router as ai_router       # ← NEW
 
 # ── App init ────────────────────────────────────────────────────────────────
@@ -90,6 +91,7 @@ app.include_router(analytics_router,     prefix=f"{api_prefix}/analytics",    ta
 app.include_router(tasks_router,         prefix=f"{api_prefix}/tasks",        tags=["tasks"])
 app.include_router(appointments_router,  prefix=f"{api_prefix}/appointments", tags=["appointments"])
 app.include_router(deals_router,         prefix=f"{api_prefix}/deals",        tags=["deals"])
+app.include_router(appraisals_router,   prefix=f"{api_prefix}/appraisals",   tags=["appraisals"])
 app.include_router(comps_router,         prefix=f"{api_prefix}",              tags=["comps"])
 app.include_router(search_router,        prefix=f"{api_prefix}",              tags=["search"])
 

--- a/app/models.py
+++ b/app/models.py
@@ -1,7 +1,7 @@
 # app/models.py
 
 from datetime import date, datetime, time
-from typing import Optional, List
+from typing import Optional, List, Literal, Any
 from pydantic import BaseModel, EmailStr, root_validator, validator, ConfigDict, Field
 
 # ── Analytics Schema ─────────────────────────────────────────────────────────
@@ -328,4 +328,40 @@ class InventoryItemUpdate(CamelModel):
     status_code: Optional[str] = None
     days_in_stock: Optional[int] = None
     image_url: Optional[List[str]] = None
+
+
+# ── Appraisals ───────────────────────────────────────────────────────────────
+
+class AppraisalBase(BaseModel):
+    customer_id: int
+    vehicle_vin: str
+    year: Optional[int] = None
+    make: Optional[str] = None
+    model: Optional[str] = None
+    trim: Optional[str] = None
+    mileage: Optional[int] = None
+    exterior_color: Optional[str] = None
+    interior_color: Optional[str] = None
+    engine: Optional[str] = None
+    transmission: Optional[str] = None
+    drivetrain: Optional[str] = None
+    condition_score: Optional[float] = None
+    damage_report: Optional[Any] = None
+    notes: Optional[str] = None
+    appraisal_value: Optional[float] = None
+    actual_acv: Optional[float] = None
+    payoff_amount: Optional[float] = None
+    status: Optional[Literal["Draft", "Final", "Rejected"]] = "Draft"
+
+
+class AppraisalCreate(AppraisalBase):
+    pass
+
+
+class Appraisal(AppraisalBase):
+    id: str
+    created_by: Optional[int] = None
+    created_at: Optional[datetime] = None
+    updated_at: Optional[datetime] = None
+
 

--- a/app/routers/appraisals.py
+++ b/app/routers/appraisals.py
@@ -1,0 +1,109 @@
+"""Endpoints for vehicle appraisals."""
+
+from fastapi import APIRouter, HTTPException, Depends
+from postgrest.exceptions import APIError
+
+from app.db import supabase
+from app.models import Appraisal, AppraisalCreate
+
+
+router = APIRouter()
+
+
+def get_current_user():
+    """Placeholder auth dependency.
+
+    This project does not implement authentication in tests, so this function
+    simply returns a minimal object with an ``id`` and ``role`` attribute. In a
+    real application, replace this with actual authentication logic.
+    """
+
+    class _User:
+        id = 1
+        role = "Admin"
+
+    return _User()
+
+
+def manager_only(user=Depends(get_current_user)):
+    if user.role not in {"Manager", "Admin"}:
+        raise HTTPException(403, "Managers only")
+    return user
+
+
+@router.get("/", response_model=list[Appraisal])
+def list_appraisals():
+    res = supabase.table("appraisals").select("*").execute()
+    return res.data or []
+
+
+@router.get("/{appraisal_id}", response_model=Appraisal)
+def get_appraisal(appraisal_id: str):
+    try:
+        res = (
+            supabase.table("appraisals")
+            .select("*")
+            .eq("id", appraisal_id)
+            .single()
+            .execute()
+        )
+    except APIError as e:
+        raise HTTPException(404, detail=e.message)
+
+    if not res.data:
+        raise HTTPException(404, "Not found")
+    return res.data
+
+
+@router.post(
+    "/",
+    response_model=Appraisal,
+    status_code=201,
+    dependencies=[Depends(manager_only)],
+)
+def create_appraisal(appraisal: AppraisalCreate, user=Depends(get_current_user)):
+    payload = appraisal.model_dump()
+    payload["created_by"] = user.id
+    try:
+        res = supabase.table("appraisals").insert(payload).execute()
+    except APIError as e:
+        raise HTTPException(400, detail=e.message)
+
+    data = res.data[0] if isinstance(res.data, list) else res.data
+    return data
+
+
+@router.put(
+    "/{appraisal_id}",
+    response_model=Appraisal,
+    dependencies=[Depends(manager_only)],
+)
+def update_appraisal(appraisal_id: str, appraisal: AppraisalCreate):
+    payload = appraisal.model_dump()
+    try:
+        res = (
+            supabase.table("appraisals")
+            .update(payload)
+            .eq("id", appraisal_id)
+            .execute()
+        )
+    except APIError as e:
+        raise HTTPException(400, detail=e.message)
+
+    if not res.data:
+        raise HTTPException(404, "Not found")
+    return res.data[0]
+
+
+@router.delete(
+    "/{appraisal_id}",
+    status_code=204,
+    dependencies=[Depends(manager_only)],
+)
+def delete_appraisal(appraisal_id: str):
+    try:
+        supabase.table("appraisals").delete().eq("id", appraisal_id).execute()
+    except APIError as e:
+        raise HTTPException(404, detail=e.message)
+    return None
+


### PR DESCRIPTION
## Summary
- add Pydantic models for appraisals
- create router with CRUD endpoints backed by Supabase
- register the appraisal routes in `app/main.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b1536ecd083228e7cf493277fb8b3