### PR TITLE
Add damage report model and image upload endpoint

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1,7 +1,7 @@
 # app/models.py
 
 from datetime import date, datetime, time
-from typing import Optional, List, Literal, Any
+from typing import Optional, List, Literal
 from pydantic import BaseModel, EmailStr, root_validator, validator, ConfigDict, Field
 
 # ── Analytics Schema ─────────────────────────────────────────────────────────
@@ -332,6 +332,14 @@ class InventoryItemUpdate(CamelModel):
 
 # ── Appraisals ───────────────────────────────────────────────────────────────
 
+class DamageReport(BaseModel):
+    """Basic structure for AI-generated damage reports."""
+    dents: Optional[int] = 0
+    scratches: Optional[int] = 0
+    tire: Optional[str] = None
+    # Additional fields can be added as needed
+
+
 class AppraisalBase(BaseModel):
     customer_id: int
     vehicle_vin: str
@@ -346,7 +354,7 @@ class AppraisalBase(BaseModel):
     transmission: Optional[str] = None
     drivetrain: Optional[str] = None
     condition_score: Optional[float] = None
-    damage_report: Optional[Any] = None
+    damage_report: Optional[DamageReport] = None
     notes: Optional[str] = None
     appraisal_value: Optional[float] = None
     actual_acv: Optional[float] = None

--- a/app/routers/appraisals.py
+++ b/app/routers/appraisals.py
@@ -107,3 +107,9 @@ def delete_appraisal(appraisal_id: str):
         raise HTTPException(404, detail=e.message)
     return None
 
+
+@router.post("/{appraisal_id}/images")
+def upload_appraisal_images(appraisal_id: str):
+    """Handle uploaded images and run AI to update the damage report (stub)."""
+    return {"success": True}
+


### PR DESCRIPTION
## Summary
- expand appraisal models with `DamageReport` typed submodel
- expose a stub route for uploading appraisal images

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b17c0aa68832294154ac5646745c7