### PR TITLE
Implement global ThemeContext

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,5 +1,6 @@
 // src/App.jsx
 import { useState, useEffect, useRef } from 'react';
+import { useTheme } from './context/ThemeContext.jsx';
 import { BrowserRouter as Router, Routes, Route, Link } from "react-router-dom";
 
 import LeadLog                from "./routes/LeadLog";
@@ -27,21 +28,12 @@ console.log({ Home, Logo });
 
 
 export default function App() {
-  // Track dark mode preference
-  const [isDark, setIsDark] = useState(
-    window.matchMedia?.("(prefers-color-scheme: dark)")?.matches ?? false
-  );
+  const { theme } = useTheme();
+  const isDark = theme === 'dark';
   const [customerMenuOpen, setCustomerMenuOpen] = useState(false);
   const [logMenuOpen, setLogMenuOpen] = useState(false);
   const [lightText, setLightText] = useState(false);
   const navRef = useRef(null);
-
-  useEffect(() => {
-    const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
-    const handler = (e) => setIsDark(e.matches);
-    mediaQuery.addEventListener("change", handler);
-    return () => mediaQuery.removeEventListener("change", handler);
-  }, []);
 
   useEffect(() => {
     const navEl = navRef.current;

--- a/frontend/src/context/ThemeContext.jsx
+++ b/frontend/src/context/ThemeContext.jsx
@@ -1,0 +1,28 @@
+import { createContext, useContext, useEffect, useState } from "react";
+
+const ThemeContext = createContext();
+
+export function ThemeProvider({ children }) {
+  // Prefer localStorage value, fall back to OS preference
+  const getInitialTheme = () =>
+    localStorage.getItem("theme") ||
+    (window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light");
+
+  const [theme, setTheme] = useState(getInitialTheme);
+
+  // Update the html class and persist preference
+  useEffect(() => {
+    document.documentElement.classList.toggle("dark", theme === "dark");
+    localStorage.setItem("theme", theme);
+  }, [theme]);
+
+  return (
+    <ThemeContext.Provider value={{ theme, setTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+export function useTheme() {
+  return useContext(ThemeContext);
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,5 +1,6 @@
 import { createRoot } from 'react-dom/client'
 import App from './App.jsx'
+import { ThemeProvider } from './context/ThemeContext.jsx'
 import './index.css'
 
 const container = document.getElementById('root')
@@ -8,7 +9,9 @@ if (!container) {
 }
 const root = createRoot(container)
 root.render(
-  <div className="page-frame">
-    <App />
-  </div>
+  <ThemeProvider>
+    <div className="page-frame">
+      <App />
+    </div>
+  </ThemeProvider>
 )

--- a/frontend/src/routes/CustomerCard.jsx
+++ b/frontend/src/routes/CustomerCard.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { useTheme } from '../context/ThemeContext.jsx';
 import { useParams, Link } from 'react-router-dom'
 import { formatDateTime } from '../utils/formatDateTime'
 import {
@@ -49,7 +50,7 @@ export default function CustomerCard({ userRole = "sales" }) {
   const [note, setNote] = useState('')
   const [aiInfo, setAiInfo] = useState({})
   const [tab, setTab] = useState('profile')
-  const [theme, setTheme] = useState(window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light')
+  const { theme, setTheme } = useTheme()
   const [isOnline, setIsOnline] = useState(false)
   const [social, setSocial] = useState({ linkedin: '', facebook: '', twitter: '', found: false })
   const [files, setFiles] = useState([])
@@ -160,9 +161,6 @@ export default function CustomerCard({ userRole = "sales" }) {
     fetch(`${API_BASE}/customers/${id}/files`).then(r => r.json()).then(docs => setFiles(docs || []))
   }
 
-  useEffect(() => {
-    document.documentElement.classList.toggle('dark', theme === 'dark')
-  }, [theme])
 
   if (loading) return <div className="flex justify-center items-center h-48">Loading...</div>
   if (!customer) return <div>Customer not found</div>

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,6 +1,6 @@
 export default {
   content: ["./index.html", "./src/**/*.{js,jsx,ts,tsx}"],
-  darkMode: 'media', // respect OS setting; or 'class' to toggle manually
+  darkMode: 'class', // use class strategy so ThemeContext can control dark mode
   theme: {
     extend: {
       colors: {


### PR DESCRIPTION
## Summary
- add a `ThemeContext` provider for dark mode
- wrap app with the provider in `main.jsx`
- use the context in `App.jsx` and `CustomerCard.jsx`
- switch Tailwind to `class` based dark mode

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ba22940bc83228de7fe86dfc896d7