### PR TITLE
Add deals API models and tests

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -372,4 +372,36 @@ class Appraisal(AppraisalBase):
     created_at: Optional[datetime] = None
     updated_at: Optional[datetime] = None
 
+# ── Deals ─────────────────────────────────────────────────────────────────
+
+class DealBase(BaseModel):
+    customer_id: int
+    vehicle: Optional[str] = None
+    trade: Optional[str] = None
+    amount: Optional[float] = None
+    stage: Optional[str] = "new"
+    status: Optional[str] = None
+    notes: Optional[str] = None
+    salesperson: Optional[str] = None
+    sold: Optional[bool] = None
+    close_date: Optional[str] = None
+
+class DealCreate(DealBase):
+    pass
+
+class DealUpdate(BaseModel):
+    customer_id: Optional[int] = None
+    vehicle: Optional[str] = None
+    trade: Optional[str] = None
+    amount: Optional[float] = None
+    stage: Optional[str] = None
+    status: Optional[str] = None
+    notes: Optional[str] = None
+    salesperson: Optional[str] = None
+    sold: Optional[bool] = None
+    close_date: Optional[str] = None
+
+class Deal(DealBase):
+    id: int
+
 

--- a/app/routers/deals.py
+++ b/app/routers/deals.py
@@ -1,26 +1,11 @@
 # app/routers/deals.py
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, status
 from postgrest.exceptions import APIError
 from app.db import supabase
-from pydantic import BaseModel
 from typing import Optional
+from app.models import Deal, DealCreate, DealUpdate
 
 router = APIRouter()
-
-class DealCreate(BaseModel):
-    customer_id: int
-    vehicle: Optional[str]
-    trade: Optional[str]
-    amount: Optional[float]
-    stage: Optional[str] = "new"
-    status: Optional[str]
-    notes: Optional[str]
-    salesperson: Optional[str]
-    sold: Optional[bool]
-    close_date: Optional[str]
-
-class Deal(DealCreate):
-    id: int
 
 @router.get("/", response_model=list[Deal])
 @router.get("", response_model=list[Deal], include_in_schema=False)
@@ -34,11 +19,51 @@ def list_deals(customer_id: Optional[int] = None):
     except APIError as e:
         raise HTTPException(400, detail=e.message)
 
-@router.post("/", response_model=Deal)
-@router.post("", response_model=Deal, include_in_schema=False)
+@router.post("/", response_model=Deal, status_code=status.HTTP_201_CREATED)
+@router.post("", response_model=Deal, include_in_schema=False, status_code=status.HTTP_201_CREATED)
 def create_deal(deal: DealCreate):
     try:
         res = supabase.table("deals").insert(deal.dict()).execute()
         return res.data[0]
     except APIError as e:
         raise HTTPException(400, detail=e.message)
+
+
+@router.get("/{deal_id}", response_model=Deal)
+def get_deal(deal_id: int):
+    try:
+        res = (
+            supabase
+            .table("deals")
+            .select("*")
+            .eq("id", deal_id)
+            .maybe_single()
+            .execute()
+        )
+    except APIError as e:
+        raise HTTPException(400, detail=e.message)
+
+    if not res.data:
+        raise HTTPException(status_code=404, detail="Deal not found")
+    return res.data
+
+
+@router.patch("/{deal_id}", response_model=Deal)
+def update_deal(deal_id: int, deal: DealUpdate):
+    payload = {k: v for k, v in deal.dict(exclude_unset=True).items() if v is not None}
+    if not payload:
+        raise HTTPException(status_code=400, detail="No fields to update")
+    try:
+        res = (
+            supabase
+            .table("deals")
+            .update(payload)
+            .eq("id", deal_id)
+            .execute()
+        )
+    except APIError as e:
+        raise HTTPException(400, detail=e.message)
+
+    if not res.data:
+        raise HTTPException(status_code=404, detail="Deal not found")
+    return res.data[0]

--- a/tests/test_deals.py
+++ b/tests/test_deals.py
@@ -1,0 +1,118 @@
+from fastapi.testclient import TestClient
+from unittest.mock import MagicMock, patch
+from app.main import app
+
+client = TestClient(app)
+
+
+def test_list_deals():
+    sample = [{
+        "id": 1,
+        "customer_id": 1,
+        "vehicle": "Car",
+        "trade": None,
+        "amount": None,
+        "stage": "new",
+        "status": None,
+        "notes": None,
+        "salesperson": None,
+        "sold": None,
+        "close_date": None,
+    }]
+    exec_result = MagicMock(data=sample, error=None)
+    mock_table = MagicMock()
+    mock_table.select.return_value.execute.return_value = exec_result
+    mock_supabase = MagicMock()
+    mock_supabase.table.return_value = mock_table
+
+    with patch("app.routers.deals.supabase", mock_supabase):
+        response = client.get("/api/deals/")
+
+    assert response.status_code == 200
+    assert response.json() == sample
+
+
+def test_get_deal():
+    sample = {
+        "id": 1,
+        "customer_id": 1,
+        "vehicle": "Car",
+        "trade": None,
+        "amount": None,
+        "stage": "new",
+        "status": None,
+        "notes": None,
+        "salesperson": None,
+        "sold": None,
+        "close_date": None,
+    }
+    exec_result = MagicMock(data=sample, error=None)
+    mock_select = MagicMock()
+    mock_select.eq.return_value.maybe_single.return_value.execute.return_value = exec_result
+    mock_table = MagicMock()
+    mock_table.select.return_value = mock_select
+    mock_supabase = MagicMock()
+    mock_supabase.table.return_value = mock_table
+
+    with patch("app.routers.deals.supabase", mock_supabase):
+        response = client.get("/api/deals/1")
+
+    assert response.status_code == 200
+    assert response.json() == sample
+    mock_select.eq.assert_called_with("id", 1)
+
+
+def test_create_deal():
+    payload = {"customer_id": 1, "vehicle": "Car"}
+    sample = {
+        "id": 1,
+        "customer_id": 1,
+        "vehicle": "Car",
+        "trade": None,
+        "amount": None,
+        "stage": "new",
+        "status": None,
+        "notes": None,
+        "salesperson": None,
+        "sold": None,
+        "close_date": None,
+    }
+    exec_result = MagicMock(data=[sample], error=None)
+    mock_table = MagicMock()
+    mock_table.insert.return_value.execute.return_value = exec_result
+    mock_supabase = MagicMock()
+    mock_supabase.table.return_value = mock_table
+
+    with patch("app.routers.deals.supabase", mock_supabase):
+        response = client.post("/api/deals/", json=payload)
+
+    assert response.status_code == 201
+    assert response.json() == sample
+
+
+def test_update_deal():
+    sample = {
+        "id": 1,
+        "customer_id": 1,
+        "vehicle": "New Car",
+        "trade": None,
+        "amount": None,
+        "stage": "new",
+        "status": None,
+        "notes": None,
+        "salesperson": None,
+        "sold": None,
+        "close_date": None,
+    }
+    exec_result = MagicMock(data=[sample], error=None)
+    mock_table = MagicMock()
+    mock_table.update.return_value.eq.return_value.execute.return_value = exec_result
+    mock_supabase = MagicMock()
+    mock_supabase.table.return_value = mock_table
+
+    with patch("app.routers.deals.supabase", mock_supabase):
+        response = client.patch("/api/deals/1", json={"vehicle": "New Car"})
+
+    assert response.status_code == 200
+    assert response.json() == sample
+


### PR DESCRIPTION
## Summary
- define Deal models in `app/models.py`
- extend deals router with detail and update endpoints
- add unit tests for listing, retrieving, creating and updating deals

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687bb5f439c883229447c2653894bc32