### PR TITLE
Add KPI overlay modal and adjust API responses

### DIFF
--- a/app/routers/deals.py
+++ b/app/routers/deals.py
@@ -52,11 +52,7 @@ def list_deals(
             # Filter for deals sold this month
             query = query.gte("sold_date", f"{month}-01").lte("sold_date", f"{month}-31")
         res = query.execute()
-        deals = res.data or []
-        # Add days_to_book to each deal
-        for deal in deals:
-            deal["days_to_book"] = days_to_book(deal.get("sold_date"), deal.get("booked_date"))
-        return deals
+        return res.data or []
     except APIError as e:
         raise HTTPException(400, detail=e.message)
 
@@ -77,9 +73,7 @@ def get_deal(deal_id: int):
     if not res.data:
         raise HTTPException(status_code=404, detail="Deal not found")
 
-    deal = res.data
-    deal["days_to_book"] = days_to_book(deal.get("sold_date"), deal.get("booked_date"))
-    return deal
+    return res.data
 
 @router.post("/", response_model=Deal, status_code=status.HTTP_201_CREATED, dependencies=[Depends(manager_required)])
 @router.post("", response_model=Deal, include_in_schema=False, status_code=status.HTTP_201_CREATED, dependencies=[Depends(manager_required)])
@@ -118,9 +112,7 @@ def update_deal(deal_id: int, deal: DealUpdate, user=Depends(get_current_user)):
         if not res.data:
             raise HTTPException(status_code=404, detail="Deal not found")
         log_audit_action(deal_id, "update", user["id"], str(payload))
-        deal = res.data[0]
-        deal["days_to_book"] = days_to_book(deal.get("sold_date"), deal.get("booked_date"))
-        return deal
+        return res.data[0]
     except APIError as e:
         raise HTTPException(400, detail=e.message)
 
@@ -148,9 +140,7 @@ def unwind_deal(
         if not res.data:
             raise HTTPException(status_code=404, detail="Deal not found")
         log_audit_action(deal_id, "unwind", user["id"], reason)
-        deal = res.data[0]
-        deal["days_to_book"] = days_to_book(deal.get("sold_date"), deal.get("booked_date"))
-        return deal
+        return res.data[0]
     except APIError as e:
         raise HTTPException(400, detail=e.message)
 

--- a/frontend/src/components/KpiInventoryDetail.jsx
+++ b/frontend/src/components/KpiInventoryDetail.jsx
@@ -1,0 +1,27 @@
+import { useEffect } from 'react';
+
+export default function KpiInventoryDetail({ onClose }) {
+  useEffect(() => {
+    const handler = (e) => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [onClose]);
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-60 z-50 flex items-center justify-center">
+      <div className="bg-white rounded-xl shadow-2xl max-w-3xl w-full p-6 relative">
+        <button
+          className="absolute top-3 right-3 text-2xl"
+          onClick={onClose}
+          aria-label="Close"
+        >
+          &times;
+        </button>
+        <h2 className="text-xl font-bold mb-4">Inventory Details</h2>
+        {/* ...KPI details go here... */}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -20,6 +20,7 @@ import NotificationsBar from "../components/NotificationsBar";
 import ProductivityWidget from "../components/ProductivityWidget";
 import QuickActionPanel from "../components/QuickActionPanel";
 import SmartSearchBar from "../components/SmartSearchBar";
+import KpiInventoryDetail from "../components/KpiInventoryDetail";
 // import MultiRooftopSwitcher from "../components/MultiRooftopSwitcher";
 
 import useAuth from "../hooks/useAuth";
@@ -38,6 +39,7 @@ console.log({
 
 export default function Home() {
   const [showHero, setShowHero] = useState(true);
+  const [openKpi, setOpenKpi] = useState(null);
   const { user } = useAuth();
 
   useEffect(() => {
@@ -50,9 +52,10 @@ export default function Home() {
   }, []);
 
   // Use Sparklines for correct import!
-  const AnimatedCard = ({ to, children, delay = 0, sparklineData }) => (
+  const AnimatedCard = ({ to = '#', onClick, children, delay = 0, sparklineData }) => (
     <Link
       to={to}
+      onClick={onClick}
       className="group block bg-white rounded-2xl shadow-xl p-7 hover:shadow-2xl hover:bg-blue-50 transition"
     >
       <Motion.div
@@ -135,28 +138,28 @@ export default function Home() {
 
           {/* KPIs Section */}
           <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-8">
-            <AnimatedCard to="/kpi/sales-activity" delay={0.08} sparklineData={[8, 9, 12, 10, 14, 17]}>
+            <AnimatedCard to="#" onClick={() => setOpenKpi('sales-activity')} delay={0.08} sparklineData={[8, 9, 12, 10, 14, 17]}>
               <SalesTeamActivity />
             </AnimatedCard>
-            <AnimatedCard to="/kpi/sales-performance" delay={0.15} sparklineData={[22, 28, 25, 27, 32, 30]}>
+            <AnimatedCard to="#" onClick={() => setOpenKpi('sales-performance')} delay={0.15} sparklineData={[22, 28, 25, 27, 32, 30]}>
               <SalesPerformanceKPI />
             </AnimatedCard>
-            <AnimatedCard to="/kpi/lead-performance" delay={0.21} sparklineData={[45, 44, 48, 51, 47, 53]}>
+            <AnimatedCard to="#" onClick={() => setOpenKpi('lead-performance')} delay={0.21} sparklineData={[45, 44, 48, 51, 47, 53]}>
               <LeadPerformanceKPI />
             </AnimatedCard>
-            <AnimatedCard to="/kpi/inventory-snapshot" delay={0.26} sparklineData={[202, 207, 208, 205, 200, 199]}>
+            <AnimatedCard to="#" onClick={() => setOpenKpi('inventory-snapshot')} delay={0.26} sparklineData={[202, 207, 208, 205, 200, 199]}>
               <InventorySnapshot />
             </AnimatedCard>
-            <AnimatedCard to="/kpi/ai-overview" delay={0.32}>
+            <AnimatedCard to="#" onClick={() => setOpenKpi('ai-overview')} delay={0.32}>
               <AIOverview />
             </AnimatedCard>
-            <AnimatedCard to="/kpi/service-performance" delay={0.36} sparklineData={[97, 105, 110, 102, 108, 111]}>
+            <AnimatedCard to="#" onClick={() => setOpenKpi('service-performance')} delay={0.36} sparklineData={[97, 105, 110, 102, 108, 111]}>
               <ServiceDepartmentPerformance />
             </AnimatedCard>
-            <AnimatedCard to="/kpi/customer-satisfaction" delay={0.4} sparklineData={[4.5, 4.7, 4.8, 4.9, 4.7, 5.0]}>
+            <AnimatedCard to="#" onClick={() => setOpenKpi('customer-satisfaction')} delay={0.4} sparklineData={[4.5, 4.7, 4.8, 4.9, 4.7, 5.0]}>
               <CustomerSatisfaction />
             </AnimatedCard>
-            <AnimatedCard to="/kpi/marketing-roi" delay={0.45} sparklineData={[1.4, 2.1, 2.0, 2.2, 2.5, 2.7]}>
+            <AnimatedCard to="#" onClick={() => setOpenKpi('marketing-roi')} delay={0.45} sparklineData={[1.4, 2.1, 2.0, 2.2, 2.5, 2.7]}>
               <MarketingCampaignROI />
             </AnimatedCard>
           </div>
@@ -166,6 +169,10 @@ export default function Home() {
             <AIWidget />
           </div>
         </Motion.div>
+      )}
+
+      {openKpi === 'inventory-snapshot' && (
+        <KpiInventoryDetail onClose={() => setOpenKpi(null)} />
       )}
 
       <style>{`


### PR DESCRIPTION
## Summary
- create `KpiInventoryDetail` modal component
- open KPI cards in `Home` with overlay instead of navigation
- drop `days_to_book` field from deals API responses
- simplify inventory snapshot API output

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687be6c7dc9c8322884d59fbd25ca67b