### PR TITLE
Revert KPI overlay modal

### DIFF
--- a/tests/test_deals.py
+++ b/tests/test_deals.py
@@ -19,7 +19,7 @@ def test_list_deals():
         "sold": None,
         "close_date": None,
     }]
-    exec_result = MagicMock(data=sample, error=None)
+    exec_result = MagicMock(data=[sample[0].copy()], error=None)
     mock_table = MagicMock()
     mock_table.select.return_value.execute.return_value = exec_result
     mock_supabase = MagicMock()
@@ -46,7 +46,7 @@ def test_get_deal():
         "sold": None,
         "close_date": None,
     }
-    exec_result = MagicMock(data=sample, error=None)
+    exec_result = MagicMock(data=sample.copy(), error=None)
     mock_select = MagicMock()
     mock_select.eq.return_value.maybe_single.return_value.execute.return_value = exec_result
     mock_table = MagicMock()
@@ -77,7 +77,7 @@ def test_create_deal():
         "sold": None,
         "close_date": None,
     }
-    exec_result = MagicMock(data=[sample], error=None)
+    exec_result = MagicMock(data=[sample.copy()], error=None)
     mock_table = MagicMock()
     mock_table.insert.return_value.execute.return_value = exec_result
     mock_supabase = MagicMock()
@@ -104,7 +104,7 @@ def test_update_deal():
         "sold": None,
         "close_date": None,
     }
-    exec_result = MagicMock(data=[sample], error=None)
+    exec_result = MagicMock(data=[sample.copy()], error=None)
     mock_table = MagicMock()
     mock_table.update.return_value.eq.return_value.execute.return_value = exec_result
     mock_supabase = MagicMock()

--- a/tests/test_inventory.py
+++ b/tests/test_inventory.py
@@ -71,9 +71,9 @@ def test_filter_inventory_query_params():
 
 def test_inventory_snapshot():
     sample = [
-        {"type": "new"},
-        {"type": "used"},
-        {"type": "new"},
+        {"type": "new", "StatusCode": "in_stock"},
+        {"type": "used", "StatusCode": "in_stock"},
+        {"type": "new", "StatusCode": "in_stock"},
     ]
     exec_result = MagicMock(data=sample, error=None)
     mock_table = MagicMock()
@@ -85,4 +85,29 @@ def test_inventory_snapshot():
         response = client.get("/api/inventory/snapshot")
 
     assert response.status_code == 200
-    assert response.json() == {"total": 3, "new": 2, "used": 1}
+    assert response.json() == {
+        "new": {
+            "total": 2,
+            "avgDays": 0,
+            "turnRate": 0,
+            "buckets": {
+                "0-30": 0,
+                "31-45": 0,
+                "46-60": 0,
+                "61-90": 0,
+                "90+": 0,
+            },
+        },
+        "used": {
+            "total": 1,
+            "avgDays": 0,
+            "turnRate": 0,
+            "buckets": {
+                "0-30": 0,
+                "31-45": 0,
+                "46-60": 0,
+                "61-90": 0,
+                "90+": 0,
+            },
+        },
+    }


### PR DESCRIPTION
## Summary
- revert prior overlay commit restoring KPI links
- update inventory snapshot API back to full stats
- adjust tests for reverted behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687be6c7dc9c8322884d59fbd25ca67b