### PR TITLE
Fix multiple Supabase client instances

### DIFF
--- a/frontend/src/components/CreateFloorTrafficForm.jsx
+++ b/frontend/src/components/CreateFloorTrafficForm.jsx
@@ -1,10 +1,7 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { createClient } from '@supabase/supabase-js';
+import supabase from '../supabase';
 
-const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
-const supabaseKey = import.meta.env.VITE_SUPABASE_KEY;
-const supabase = createClient(supabaseUrl, supabaseKey);
 
 export default function CreateFloorTrafficForm() {
   const navigate = useNavigate();

--- a/frontend/src/pages/FloorTrafficPage.jsx
+++ b/frontend/src/pages/FloorTrafficPage.jsx
@@ -1,13 +1,10 @@
 import { useEffect, useState } from 'react';
-import { createClient } from '@supabase/supabase-js';
+import supabase from '../supabase';
 import FloorTrafficTable from '../components/FloorTrafficTable';
 import FloorTrafficModal from '../components/FloorTrafficModal';
 import { Users, MailCheck, Activity, XCircle } from 'lucide-react';
 import { Card, CardContent } from '../components/ui/card';
 
-const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
-const supabaseKey = import.meta.env.VITE_SUPABASE_KEY;
-const supabase = supabaseUrl && supabaseKey ? createClient(supabaseUrl, supabaseKey) : null;
 
 export default function FloorTrafficPage() {
   const API_BASE = import.meta.env.PROD

--- a/frontend/src/routes/FloorLog.jsx
+++ b/frontend/src/routes/FloorLog.jsx
@@ -1,11 +1,8 @@
 import { useEffect, useState } from 'react';
 import { Users } from 'lucide-react';
 import { formatTime } from '../utils/formatDateTime';
-import { createClient } from '@supabase/supabase-js';
+import supabase from '../supabase';
 
-const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
-const supabaseKey = import.meta.env.VITE_SUPABASE_KEY;
-const supabase = supabaseUrl && supabaseKey ? createClient(supabaseUrl, supabaseKey) : null;
 
 export default function FloorLog() {
   const [logs, setLogs] = useState([]);

--- a/frontend/src/supabase.js
+++ b/frontend/src/supabase.js
@@ -1,0 +1,9 @@
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
+const supabaseKey = import.meta.env.VITE_SUPABASE_KEY;
+
+export const supabase =
+  supabaseUrl && supabaseKey ? createClient(supabaseUrl, supabaseKey) : null;
+
+export default supabase;


### PR DESCRIPTION
## Summary
- avoid creating multiple Supabase clients by providing a shared helper
- refactor pages and components to import the singleton client

## Testing
- `npm run lint` *(fails: 13 errors, 14 warnings)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688583c57d608322844204495005ff5b