### PR TITLE
Make customer names link to profile

### DIFF
--- a/frontend/src/components/CustomerNameLink.jsx
+++ b/frontend/src/components/CustomerNameLink.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+export default function CustomerNameLink({ id, name }) {
+  if (!id) return <span>{name || ''}</span>;
+  return (
+    <Link
+      to={`/customers/${id}`}
+      title="View customer card"
+      className="text-blue-600 hover:underline"
+    >
+      {name}
+    </Link>
+  );
+}

--- a/frontend/src/components/FloorTrafficTable.jsx
+++ b/frontend/src/components/FloorTrafficTable.jsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { Phone, MessageCircle, Mail, Pencil, ChevronUp, ChevronDown } from 'lucide-react';
 import { Progress } from './ui/progress'; // adjust path if needed
 import { formatTime } from '../utils/formatDateTime';
+import CustomerNameLink from './CustomerNameLink';
 
 export default function FloorTrafficTable({ rows = [], onEdit, onToggle }) {
   const [sortConfig, setSortConfig] = useState({ key: 'visit_time', direction: 'ascending' });
@@ -100,7 +101,9 @@ export default function FloorTrafficTable({ rows = [], onEdit, onToggle }) {
         <td className="p-2">{row.salesperson || ''}</td>
 
         {/* Customer Name */}
-        <td className="p-2">{row.customer_name || ''}</td>
+        <td className="p-2">
+          <CustomerNameLink id={row.customer_id} name={row.customer_name || ''} />
+        </td>
 
         {/* Vehicle */}
         <td className="p-2">{row.vehicle || ''}</td>

--- a/frontend/src/pages/AppraisalsPage.jsx
+++ b/frontend/src/pages/AppraisalsPage.jsx
@@ -5,6 +5,7 @@ import {
   ArrowUpRight, Search, MessageCircle, Image, Mic, Zap,
   TrendingUp, TrendingDown, Printer, Share2, Edit3, Save, X, CheckCircle
 } from "lucide-react";
+import CustomerNameLink from "../components/CustomerNameLink";
 
 // ----------- MOCK MARKET COMPS (for demo) --------------
 const mockComps = [
@@ -53,7 +54,10 @@ export default function AppraisalsPage() {
   const getCustomerName = (id) => {
     if (!id) return <span className="italic text-gray-400">No Customer</span>;
     const c = customers.find((cust) => String(cust.id) === String(id));
-    if (c) return c.name || `${c.first_name || ""} ${c.last_name || ""}`.trim();
+    if (c) {
+      const name = c.name || `${c.first_name || ""} ${c.last_name || ""}`.trim();
+      return <CustomerNameLink id={c.id} name={name} />;
+    }
     return <span className="italic text-gray-400">Unknown</span>;
   };
 

--- a/frontend/src/pages/DealsPage.jsx
+++ b/frontend/src/pages/DealsPage.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from "react";
 // eslint-disable-next-line no-unused-vars
 import { motion } from "framer-motion";
+import CustomerNameLink from "../components/CustomerNameLink";
 
 // Use env var for backend URL!
 const API_BASE = import.meta.env.VITE_API_BASE_URL || "";
@@ -250,10 +251,12 @@ export default function DealsPage() {
                       </span>
                     ) : field.includes("gross") ? (
                       formatCurrency(deal[field])
+                    ) : field === "customer_name" ? (
+                      <CustomerNameLink id={deal.customer_id} name={deal.customer_name} />
                     ) : (
                       deal[field] ?? "-"
                     )}
-                  </td>
+                 </td>
                 ))}
                 {/* Non-editable cells for Days to Book and Actions */}
                 <td className="py-2 px-3 text-center">

--- a/frontend/src/routes/FloorLog.jsx
+++ b/frontend/src/routes/FloorLog.jsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { Users } from 'lucide-react';
 import { formatTime } from '../utils/formatDateTime';
 import supabase from '../supabase';
+import CustomerNameLink from '../components/CustomerNameLink';
 
 
 export default function FloorLog() {
@@ -190,6 +191,8 @@ export default function FloorLog() {
                               handleToggle(log.id, key, e.target.checked);
                             }}
                           />
+                        ) : key === 'customer_name' ? (
+                          <CustomerNameLink id={log.customer_id} name={log.customer_name} />
                         ) : (
                           String(log[key] ?? '')
                         )}

--- a/frontend/src/routes/LeadLog.jsx
+++ b/frontend/src/routes/LeadLog.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import CustomerNameLink from '../components/CustomerNameLink';
 
 export default function LeadLog() {
   const API_BASE = `${import.meta.env.VITE_API_BASE_URL}/leads`;
@@ -241,7 +242,9 @@ export default function LeadLog() {
             <tbody>
               {prioritized.map(l => (
                 <tr key={l.id} className="odd:bg-gray-50 dark:odd:bg-gray-800 hover:bg-gray-100 dark:hover:bg-gray-700">
-                  <td className="p-2 whitespace-nowrap">{l.name}</td>
+                  <td className="p-2 whitespace-nowrap">
+                    <CustomerNameLink id={l.id} name={l.name} />
+                  </td>
                   <td className="p-2 whitespace-nowrap">{l.email}</td>
                   <td className="p-2 whitespace-nowrap">{formatDate(l.last_lead_response_at)}</td>
                   <td className="p-2 whitespace-nowrap">{formatDate(l.last_staff_response_at)}</td>
@@ -282,7 +285,9 @@ export default function LeadLog() {
             <tbody>
               {leads.map(l => (
                 <tr key={l.id} className="odd:bg-gray-50 dark:odd:bg-gray-800 hover:bg-gray-100 dark:hover:bg-gray-700">
-                  <td className="p-2 whitespace-nowrap">{l.name}</td>
+                  <td className="p-2 whitespace-nowrap">
+                    <CustomerNameLink id={l.id} name={l.name} />
+                  </td>
                   <td className="p-2 whitespace-nowrap">{l.email}</td>
                   <td className="p-2 whitespace-nowrap">{formatDate(l.created_at)}</td>
                   <td className="p-2 whitespace-nowrap">{formatDate(l.last_lead_response_at)}</td>
@@ -311,7 +316,9 @@ export default function LeadLog() {
             <tbody>
               {awaiting.map(l => (
                 <tr key={l.id} className="bg-red-100 dark:bg-red-900 odd:bg-red-50 dark:odd:bg-red-800 hover:bg-red-200 dark:hover:bg-red-700">
-                  <td className="p-2 whitespace-nowrap">{l.name}</td>
+                  <td className="p-2 whitespace-nowrap">
+                    <CustomerNameLink id={l.id} name={l.name} />
+                  </td>
                   <td className="p-2 whitespace-nowrap">{l.email}</td>
                   <td className="p-2 whitespace-nowrap">{formatDate(l.last_lead_response_at)}</td>
                 </tr>


### PR DESCRIPTION
## Summary
- add CustomerNameLink usage on leads page so names open the customer card

## Testing
- `pytest -q` *(fails: 14 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6887fa2f71488322b7c717521a6147c2