### PR TITLE
Add customer overlay on floor log

### DIFF
--- a/frontend/src/components/CustomerCardOverlay.jsx
+++ b/frontend/src/components/CustomerCardOverlay.jsx
@@ -1,0 +1,42 @@
+import { useEffect, useState } from 'react';
+import CustomerProfileCard from './CustomerProfileCard';
+
+export default function CustomerCardOverlay({ customerId, onClose }) {
+  const [customer, setCustomer] = useState(null);
+  const [ledger, setLedger] = useState([]);
+  const API_BASE = import.meta.env.VITE_API_BASE_URL || '/api';
+
+  useEffect(() => {
+    if (!customerId) return;
+    setCustomer(null);
+    setLedger([]);
+    fetch(`${API_BASE}/customers/${customerId}`)
+      .then(res => res.json())
+      .then(setCustomer)
+      .catch(() => setCustomer(null));
+    fetch(`${API_BASE}/activities?customer_id=${customerId}`)
+      .then(res => res.json())
+      .then(setLedger)
+      .catch(() => setLedger([]));
+  }, [customerId, API_BASE]);
+
+  if (!customerId) return null;
+
+  return (
+    <div className="fixed inset-0 bg-black/50 z-50 overflow-y-auto flex justify-center items-start p-4">
+      <div className="w-full max-w-3xl">
+        <button
+          onClick={onClose}
+          className="mb-4 text-blue-600 hover:underline bg-white px-3 py-1 rounded shadow"
+        >
+          &larr; Back to Floor Log
+        </button>
+        {customer ? (
+          <CustomerProfileCard customer={customer} ledger={ledger} />
+        ) : (
+          <div className="bg-white p-6 rounded shadow">Loading...</div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/CustomerNameLink.jsx
+++ b/frontend/src/components/CustomerNameLink.jsx
@@ -1,8 +1,20 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 
-export default function CustomerNameLink({ id, name }) {
+export default function CustomerNameLink({ id, name, onClick }) {
   if (!id) return <span>{name || ''}</span>;
+  if (typeof onClick === 'function') {
+    return (
+      <button
+        type="button"
+        onClick={() => onClick(id)}
+        title="View customer card"
+        className="text-blue-600 hover:underline"
+      >
+        {name}
+      </button>
+    );
+  }
   return (
     <Link
       to={`/customers/${id}`}

--- a/frontend/src/components/FloorTrafficTable.jsx
+++ b/frontend/src/components/FloorTrafficTable.jsx
@@ -4,7 +4,7 @@ import { Progress } from './ui/progress'; // adjust path if needed
 import { formatTime } from '../utils/formatDateTime';
 import CustomerNameLink from './CustomerNameLink';
 
-export default function FloorTrafficTable({ rows = [], onEdit, onToggle }) {
+export default function FloorTrafficTable({ rows = [], onEdit, onToggle, onCustomerClick }) {
   const [sortConfig, setSortConfig] = useState({ key: 'visit_time', direction: 'ascending' });
   const [acknowledged, setAcknowledged] = useState(new Set());
 
@@ -102,7 +102,11 @@ export default function FloorTrafficTable({ rows = [], onEdit, onToggle }) {
 
         {/* Customer Name */}
         <td className="p-2">
-          <CustomerNameLink id={row.customer_id} name={row.customer_name || ''} />
+          <CustomerNameLink
+            id={row.customer_id}
+            name={row.customer_name || ''}
+            onClick={onCustomerClick ? (id => onCustomerClick(id)) : undefined}
+          />
         </td>
 
         {/* Vehicle */}

--- a/frontend/src/pages/FloorTrafficPage.jsx
+++ b/frontend/src/pages/FloorTrafficPage.jsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import supabase from '../supabase';
 import FloorTrafficTable from '../components/FloorTrafficTable';
 import FloorTrafficModal from '../components/FloorTrafficModal';
+import CustomerCardOverlay from '../components/CustomerCardOverlay';
 import { Users, MailCheck, Activity, XCircle } from 'lucide-react';
 import { Card, CardContent } from '../components/ui/card';
 
@@ -14,6 +15,7 @@ export default function FloorTrafficPage() {
   const todayStr = new Date().toISOString().slice(0, 10);
   const [startDate, setStartDate] = useState(todayStr);
   const [endDate, setEndDate] = useState(todayStr);
+  const [selectedCustomerId, setSelectedCustomerId] = useState(null);
   const [activity, setActivity] = useState({
     salesCalls: 0,
     textMessages: 0,
@@ -403,6 +405,7 @@ export default function FloorTrafficPage() {
                 setModalOpen(true);
               }}
               onToggle={handleToggle}
+              onCustomerClick={id => setSelectedCustomerId(id)}
             />
           )}
         </CardContent>
@@ -416,6 +419,10 @@ export default function FloorTrafficPage() {
         }}
         onSubmit={handleSubmit}
         initialData={editing}
+      />
+      <CustomerCardOverlay
+        customerId={selectedCustomerId}
+        onClose={() => setSelectedCustomerId(null)}
       />
     </div>
   );

--- a/frontend/src/routes/FloorLog.jsx
+++ b/frontend/src/routes/FloorLog.jsx
@@ -3,11 +3,13 @@ import { Users } from 'lucide-react';
 import { formatTime } from '../utils/formatDateTime';
 import supabase from '../supabase';
 import CustomerNameLink from '../components/CustomerNameLink';
+import CustomerCardOverlay from '../components/CustomerCardOverlay';
 
 
 export default function FloorLog() {
   const [logs, setLogs] = useState([]);
   const [loading, setLoading] = useState(false);
+  const [selectedCustomerId, setSelectedCustomerId] = useState(null);
 
   // Match your API or Supabase field names!
   const headers = [
@@ -192,7 +194,11 @@ export default function FloorLog() {
                             }}
                           />
                         ) : key === 'customer_name' ? (
-                          <CustomerNameLink id={log.customer_id} name={log.customer_name} />
+                          <CustomerNameLink
+                            id={log.customer_id}
+                            name={log.customer_name}
+                            onClick={id => setSelectedCustomerId(id)}
+                          />
                         ) : (
                           String(log[key] ?? '')
                         )}
@@ -214,6 +220,10 @@ export default function FloorLog() {
           </tbody>
         </table>
       </div>
+      <CustomerCardOverlay
+        customerId={selectedCustomerId}
+        onClose={() => setSelectedCustomerId(null)}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- create `CustomerCardOverlay` component for showing customer profiles in a modal
- allow `CustomerNameLink` to handle a custom click
- update `FloorTrafficTable` and `FloorTrafficPage` to open overlay when customer name clicked
- support overlay in fallback `FloorLog` route

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'Client' from 'supabase')*

------
https://chatgpt.com/codex/tasks/task_e_6888d0d5441483228264ff18b259c072