### PR TITLE
Fix ActivitiesPage build error

### DIFF
--- a/frontend/src/components/CustomerNameLink.jsx
+++ b/frontend/src/components/CustomerNameLink.jsx
@@ -1,4 +1,4 @@
-iimport React from 'react';
+import React from 'react';
 import { useCustomerCard } from '../context/CustomerCardContext';
 
 export default function CustomerNameLink({ id, name }) {

--- a/frontend/src/components/ui/button.jsx
+++ b/frontend/src/components/ui/button.jsx
@@ -1,0 +1,10 @@
+export function Button({ className = '', children, ...props }) {
+  return (
+    <button
+      className={`px-4 py-2 rounded-md bg-blue-600 text-white ${className}`}
+      {...props}
+    >
+      {children}
+    </button>
+  );
+}

--- a/frontend/src/components/ui/input.jsx
+++ b/frontend/src/components/ui/input.jsx
@@ -1,0 +1,8 @@
+export function Input({ className = '', ...props }) {
+  return (
+    <input
+      className={`px-3 py-2 border rounded-md ${className}`}
+      {...props}
+    />
+  );
+}

--- a/frontend/src/pages/ActivitiesPage.jsx
+++ b/frontend/src/pages/ActivitiesPage.jsx
@@ -1,10 +1,10 @@
 import { useState, useEffect, useMemo } from "react";
 import { format, subDays } from "date-fns";
-import { Card, CardContent } from "../../components/ui/card.js"; // <- RELATIVE IMPORT
+import { Card, CardContent } from "../components/ui/card";
 // If you do not have shadcn/ui for Tabs, Button, Input, stub them or create your own:
-import { Tabs, TabsList, TabsTrigger } from "../../components/ui/tabs";
-import { Button } from "../../components/ui/button";
-import { Input } from "../../components/ui/input";
+import { Tabs, TabsList, TabsTrigger } from "../components/ui/tabs";
+import { Button } from "../components/ui/button";
+import { Input } from "../components/ui/input";
 import { ArrowUpRight, Loader2 } from "lucide-react";
 import {
   useReactTable,


### PR DESCRIPTION
## Summary
- fix relative imports in `ActivitiesPage`
- add missing UI stubs for `Button` and `Input`
- correct a typo in `CustomerNameLink` component

## Testing
- `npm run build` in `frontend`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68899cc7717c83228c51214560488d80