### PR TITLE
Remove explicit FK hint from floor traffic queries

### DIFF
--- a/frontend/src/pages/FloorTrafficPage.jsx
+++ b/frontend/src/pages/FloorTrafficPage.jsx
@@ -38,7 +38,7 @@ export default function FloorTrafficPage() {
           .from('floor_traffic_customers')
           .select(`
             *,
-            customer:customer_id!floor_traffic_customers_customer_id_fkey (
+            customer:customer_id (
               customer_name, first_name, last_name, email, phone
             )
           `)
@@ -246,7 +246,7 @@ export default function FloorTrafficPage() {
         .insert([newEntry])
         .select(`
           *,
-          customer:customer_id!floor_traffic_customers_customer_id_fkey (
+          customer:customer_id (
             customer_name, first_name, last_name, email, phone
           )
         `);


### PR DESCRIPTION
## Summary
- stop naming the floor_traffic->customer foreign key explicitly so Supabase can infer the relationship

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688d809b39848322ba27b569d1f24f1c