### PR TITLE
fix: sanitize Supabase URL to avoid 404 when adding customers

### DIFF
--- a/frontend/src/supabase.js
+++ b/frontend/src/supabase.js
@@ -1,6 +1,12 @@
 import { createClient } from '@supabase/supabase-js';
 
-const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
+// Some environments accidentally include the PostgREST path (e.g. `/rest/v1`)
+// in the Supabase URL which results in requests hitting
+// `<project-url>/rest/v1/rest/v1/...` and returning 404s.  Strip the extra
+// path if it exists so the client always receives the root project URL.
+const rawUrl = import.meta.env.VITE_SUPABASE_URL || "";
+const supabaseUrl = rawUrl.replace(/\/rest\/v1\/?$/, "");
+
 const supabaseKey = import.meta.env.VITE_SUPABASE_KEY;
 
 export const supabase =


### PR DESCRIPTION
## Summary
- strip trailing `/rest/v1` from Supabase URL to prevent double path and resulting 404s

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688e3c6a80ec8322ae5d272eacd5d18b