### PR TITLE
fix: default API base for metrics

### DIFF
--- a/frontend/src/apiBase.js
+++ b/frontend/src/apiBase.js
@@ -2,7 +2,7 @@
 
 // Main backend API URL (Vite syntax)
 export const API_BASE =
-  import.meta.env.VITE_API_URL?.replace(/\/$/, "") || "/api";
+  import.meta.env.VITE_API_BASE_URL?.replace(/\/$/, "") || "/api";
 
 // Fallback public VIN decoder, if you want it:
 export const FALLBACK_VIN_DECODER =

--- a/frontend/src/components/SalesPerformanceKPI.jsx
+++ b/frontend/src/components/SalesPerformanceKPI.jsx
@@ -1,10 +1,10 @@
 import { useEffect, useState } from 'react';
+import { API_BASE } from '../apiBase';
 
 export default function SalesPerformanceKPI() {
   const [stats, setStats] = useState({ demo: 0, worksheet: 0, offer: 0, sold: 0 });
 
   useEffect(() => {
-    const API_BASE = import.meta.env.PROD ? import.meta.env.VITE_API_BASE_URL : '/api';
     const fetchStats = async () => {
       try {
         const res = await fetch(`${API_BASE}/floor-traffic/month-metrics`);


### PR DESCRIPTION
## Summary
- ensure shared API base uses `VITE_API_BASE_URL` with `/api` fallback
- reuse shared API base in SalesPerformanceKPI to fetch month metrics reliably

## Testing
- `npm test` *(fails: Missing script "test")*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e42c247508322813dfa3ab2b5b83b