### PR TITLE
fix: sanitize supabase url

### DIFF
--- a/app/db.py
+++ b/app/db.py
@@ -2,6 +2,7 @@
 
 import os
 import logging
+import re
 from dotenv import load_dotenv
 from supabase import create_client
 from types import SimpleNamespace
@@ -17,7 +18,10 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger("db")
 
 # 3️⃣ Environment variables
-SUPABASE_URL = os.getenv("SUPABASE_URL")
+raw_url = os.getenv("SUPABASE_URL") or ""
+# Strip any trailing PostgREST path (e.g. `/rest/v1`) which would cause
+# requests to hit `<project-url>/rest/v1/rest/v1/...` and return 404s.
+SUPABASE_URL = re.sub(r"/rest/v1/?$", "", raw_url)
 SUPABASE_KEY = (
     os.getenv("SUPABASE_SERVICE_ROLE_KEY")
     or os.getenv("SUPABASE_KEY")

--- a/lib/supabaseClient.js
+++ b/lib/supabaseClient.js
@@ -3,7 +3,12 @@ import dotenv from 'dotenv';
 
 dotenv.config();
 
-const SUPABASE_URL = process.env.SUPABASE_URL;
+// Some environments accidentally include the PostgREST path (e.g. `/rest/v1`)
+// in the Supabase URL which causes requests to hit
+// `<project-url>/rest/v1/rest/v1/...` and return 404.  Strip the extra path so
+// the client always receives the root project URL.
+const rawUrl = process.env.SUPABASE_URL || '';
+const SUPABASE_URL = rawUrl.replace(/\/rest\/v1\/?$/, '');
 const SUPABASE_KEY =
   process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_KEY; // prefer service role
 

--- a/models/UserModel.js
+++ b/models/UserModel.js
@@ -1,11 +1,7 @@
 // models/UserModel.js
-import { createClient } from '@supabase/supabase-js';
-
-// Set your Supabase project credentials here or use environment variables
-const supabase = createClient(
-  process.env.SUPABASE_URL,   // Example: 'https://xyzcompany.supabase.co'
-  process.env.SUPABASE_KEY    // Example: 'public-anon-key'
-);
+// Reuse the centralized Supabase client so URL sanitization and credentials are
+// handled consistently across the backend.
+import supabase from '../lib/supabaseClient.js';
 
 export default class UserModel {
   // Fetch all users from the Supabase users table


### PR DESCRIPTION
## Summary
- trim trailing `/rest/v1` from Supabase URL to stop 404s
- reuse centralized Supabase client in user model

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e53a124548322bbb40f0772a60965