### PR TITLE
fix: standardize API_BASE paths

### DIFF
--- a/frontend/src/api/recon.js
+++ b/frontend/src/api/recon.js
@@ -1,13 +1,13 @@
 export async function fetchReconData(range = 'last30days') {
-  const API_BASE = import.meta.env.VITE_API_BASE_URL || '/api';
-  const res = await fetch(`${API_BASE}/vehicles/recon?range=${encodeURIComponent(range)}`);
+  const API_BASE = import.meta.env.VITE_API_BASE_URL || '';
+  const res = await fetch(`${API_BASE}/api/vehicles/recon?range=${encodeURIComponent(range)}`);
   if (!res.ok) throw new Error('Failed to fetch recon data');
   return res.json();
 }
 
 export async function fetchReconSteps(id) {
-  const API_BASE = import.meta.env.VITE_API_BASE_URL || '/api';
-  const res = await fetch(`${API_BASE}/vehicles/recon/steps?id=${encodeURIComponent(id)}`);
+  const API_BASE = import.meta.env.VITE_API_BASE_URL || '';
+  const res = await fetch(`${API_BASE}/api/vehicles/recon/steps?id=${encodeURIComponent(id)}`);
   if (!res.ok) throw new Error('Failed to fetch recon steps');
   return res.json();
 }

--- a/frontend/src/components/AIInventoryReview.jsx
+++ b/frontend/src/components/AIInventoryReview.jsx
@@ -3,14 +3,14 @@ import { useEffect, useState } from 'react';
 export default function AIInventoryReview({ vehicleId, open, onClose, radius = 200 }) {
   const [data, setData] = useState(null);
   const [loading, setLoading] = useState(false);
-  const API_BASE = import.meta.env.VITE_API_BASE_URL || '/api';
+  const API_BASE = import.meta.env.VITE_API_BASE_URL || '';
 
   useEffect(() => {
     if (!open) return;
     const fetchData = async () => {
       setLoading(true);
       try {
-        const res = await fetch(`${API_BASE}/ai/inventory/${vehicleId}/review`);
+        const res = await fetch(`${API_BASE}/api/ai/inventory/${vehicleId}/review`);
         const json = await res.json();
         setData(json);
       } catch {

--- a/frontend/src/components/AIOverview.jsx
+++ b/frontend/src/components/AIOverview.jsx
@@ -12,10 +12,10 @@ export default function AIOverview() {
   const [open, setOpen] = useState(false);
 
   useEffect(() => {
-    const API_BASE = import.meta.env.PROD ? import.meta.env.VITE_API_BASE_URL : '/api';
+    const API_BASE = import.meta.env.PROD ? import.meta.env.VITE_API_BASE_URL : '';
     const fetchInfo = async () => {
       try {
-        const res = await fetch(`${API_BASE}/analytics/ai-overview`);
+        const res = await fetch(`${API_BASE}/api/analytics/ai-overview`);
         if (!res.ok) return;
         const data = await res.json();
         setInfo({

--- a/frontend/src/components/ChatGPTPrompt.jsx
+++ b/frontend/src/components/ChatGPTPrompt.jsx
@@ -8,8 +8,8 @@ export default function ChatGPTPrompt() {
   const sourceRef = useRef(null);               // keep EventSource between renders
 
   // Adjust the base URL + route to match your new FastAPI handler
-  const API_BASE = import.meta.env.VITE_API_BASE_URL || '/api';
-  const STREAM_ENDPOINT = `${API_BASE}/ai/ask-stream`; // GET /ai/ask-stream?q=
+  const API_BASE = import.meta.env.VITE_API_BASE_URL || '';
+  const STREAM_ENDPOINT = `${API_BASE}/api/ai/ask-stream`; // GET /ai/ask-stream?q=
 
   /** Open modal + fire SSE request */
   const askQuestion = () => {

--- a/frontend/src/components/CustomerCardOverlay.jsx
+++ b/frontend/src/components/CustomerCardOverlay.jsx
@@ -38,7 +38,7 @@ const PROFILE_FIELDS = [
 const ANIM_PROPS = { initial: { opacity: 0, y: 20 }, animate: { opacity: 1, y: 0 }, exit: { opacity: 0, y: -20 }, transition: { duration: 0.2 } };
 
 export default function CustomerCardOverlay({ customerId, onClose, userRole = "sales" }) {
-  const API_BASE = import.meta.env.VITE_API_BASE_URL || '/api';
+  const API_BASE = import.meta.env.VITE_API_BASE_URL || '';
   const CURRENT_USER_ID = 1;
 
   const [customer, setCustomer] = useState(null);
@@ -66,7 +66,7 @@ export default function CustomerCardOverlay({ customerId, onClose, userRole = "s
   if (!customerId || !customer) return;
   const fetchHotness = async () => {
     try {
-      const res = await fetch(`${API_BASE}/customers/${customerId}/ai-hotness`);
+      const res = await fetch(`${API_BASE}/api/customers/${customerId}/ai-hotness`);
       if (res.ok) {
         const { score } = await res.json();
         setCustomer(prev => ({ ...prev, hotness: score }));
@@ -79,7 +79,7 @@ export default function CustomerCardOverlay({ customerId, onClose, userRole = "s
   const [nextAction, setNextAction] = useState('');
   useEffect(() => {
     if (!customerId) return;
-    fetch(`${API_BASE}/customers/${customerId}/ai-next-action`)
+    fetch(`${API_BASE}/api/customers/${customerId}/ai-next-action`)
       .then(res => res.json()).then(data => setNextAction(data.action));
   }, [customerId, ledger, tasks]);
 
@@ -91,14 +91,14 @@ export default function CustomerCardOverlay({ customerId, onClose, userRole = "s
   useEffect(() => {
     if (!customerId) return;
     setLoading(true);
-    fetch(`${API_BASE}/customers/${customerId}`)
+    fetch(`${API_BASE}/api/customers/${customerId}`)
       .then(r => r.json()).then(data => { setCustomer(data); setEdited(data); setLoading(false) })
       .catch(() => setLoading(false))
-    fetch(`${API_BASE}/customers/${customerId}/ai-summary`)
+    fetch(`${API_BASE}/api/customers/${customerId}/ai-summary`)
       .then(r => r.json()).then(setAiInfo)
-    fetch(`${API_BASE}/activities?customer_id=${customerId}`)
+    fetch(`${API_BASE}/api/activities?customer_id=${customerId}`)
       .then(r => r.json()).then(setLedger)
-    fetch(`${API_BASE}/customers/${customerId}/files`)
+    fetch(`${API_BASE}/api/customers/${customerId}/files`)
       .then(r => r.json()).then(docs => setFiles(docs || []))
     setTimeout(() => setSocial({
       linkedin: "https://linkedin.com/in/fake-profile",
@@ -134,21 +134,21 @@ export default function CustomerCardOverlay({ customerId, onClose, userRole = "s
 
   const fetchTasks = async () => {
     try {
-      const res = await fetch(`${API_BASE}/tasks?customer_id=${customerId}`)
+      const res = await fetch(`${API_BASE}/api/tasks?customer_id=${customerId}`)
       if (res.ok) setTasks(await res.json())
       else setTasks([])
     } catch { setTasks([]) }
   }
   const fetchAppointments = async () => {
     try {
-      const res = await fetch(`${API_BASE}/appointments?customer_id=${customerId}`)
+      const res = await fetch(`${API_BASE}/api/appointments?customer_id=${customerId}`)
       if (res.ok) setAppointments(await res.json())
       else setAppointments([])
     } catch { setAppointments([]) }
   }
   const fetchDealOffers = async () => {
     try {
-      const res = await fetch(`${API_BASE}/deals?customer_id=${customerId}`);
+      const res = await fetch(`${API_BASE}/api/deals?customer_id=${customerId}`);
       if (res.ok) setDealOffers(await res.json());
       else setDealOffers([]);
     } catch { setDealOffers([]) }
@@ -157,12 +157,12 @@ export default function CustomerCardOverlay({ customerId, onClose, userRole = "s
   const logActivity = async (type, note = '', subject = '') => {
     const payload = { activity_type: type, note, subject, customer_id: customerId, user_id: CURRENT_USER_ID }
     try {
-      await fetch(`${API_BASE}/activities`, {
+      await fetch(`${API_BASE}/api/activities`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(payload)
       })
-      fetch(`${API_BASE}/activities?customer_id=${customerId}`)
+      fetch(`${API_BASE}/api/activities?customer_id=${customerId}`)
         .then(r => r.json()).then(setLedger)
     } catch (err) { }
   }
@@ -172,7 +172,7 @@ export default function CustomerCardOverlay({ customerId, onClose, userRole = "s
       const payload = {}
       PROFILE_FIELDS.forEach(({ key }) => payload[key] = edited[key] ?? "")
       if (userRole === "manager") payload['hashed_password'] = edited['hashed_password'] ?? ""
-      const res = await fetch(`${API_BASE}/customers/${customerId}`, {
+      const res = await fetch(`${API_BASE}/api/customers/${customerId}`, {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(payload)
@@ -198,13 +198,13 @@ export default function CustomerCardOverlay({ customerId, onClose, userRole = "s
     setUploading(true)
     const form = new FormData()
     form.append("file", file)
-    const res = await fetch(`${API_BASE}/customers/${customerId}/files/smart`, { method: 'POST', body: form })
+    const res = await fetch(`${API_BASE}/api/customers/${customerId}/files/smart`, { method: 'POST', body: form })
     if (res.ok) {
       const { fields } = await res.json();
       setEdited(prev => ({ ...prev, ...fields }));
     }
     setUploading(false)
-    fetch(`${API_BASE}/customers/${customerId}/files`).then(r => r.json()).then(docs => setFiles(docs || []))
+    fetch(`${API_BASE}/api/customers/${customerId}/files`).then(r => r.json()).then(docs => setFiles(docs || []))
   }
 
   function CreditAppModal({ onClose }) {
@@ -241,7 +241,7 @@ export default function CustomerCardOverlay({ customerId, onClose, userRole = "s
     const [due, setDue] = useState('')
     const handleAdd = async () => {
       if (!title) return
-      await fetch(`${API_BASE}/tasks`, {
+      await fetch(`${API_BASE}/api/tasks`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ title, due_date: due, customer_id: customerId })
@@ -269,7 +269,7 @@ export default function CustomerCardOverlay({ customerId, onClose, userRole = "s
     const [start, setStart] = useState('')
     const handleAdd = async () => {
       if (!type || !start) return
-      await fetch(`${API_BASE}/appointments`, {
+      await fetch(`${API_BASE}/api/appointments`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ appointment_type: type, start_time: start, customer_id: customerId })

--- a/frontend/src/components/CustomerProfileCard.jsx
+++ b/frontend/src/components/CustomerProfileCard.jsx
@@ -123,13 +123,13 @@ export default function CustomerProfileCard({ customer, ledger = [], onSave }) {
   const [form, setForm] = useState(customer);
   const [activeTab, setActiveTab] = useState("Details");
   const [showEmailModal, setShowEmailModal] = useState(false);
-  const API_BASE = import.meta.env.VITE_API_BASE_URL || '/api'
+  const API_BASE = import.meta.env.VITE_API_BASE_URL || ''
   const CURRENT_USER_ID = 1
 
   const logActivity = async (type, note = '', subject = '') => {
     const payload = { activity_type: type, note, subject, customer_id: customer?.id, user_id: CURRENT_USER_ID }
     try {
-      await fetch(`${API_BASE}/activities`, {
+      await fetch(`${API_BASE}/api/activities`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(payload)

--- a/frontend/src/components/CustomerSatisfaction.jsx
+++ b/frontend/src/components/CustomerSatisfaction.jsx
@@ -13,10 +13,10 @@ export default function CustomerSatisfaction() {
   const [open, setOpen] = useState(false);
 
   useEffect(() => {
-    const API_BASE = import.meta.env.PROD ? import.meta.env.VITE_API_BASE_URL : '/api';
+    const API_BASE = import.meta.env.PROD ? import.meta.env.VITE_API_BASE_URL : '';
     const fetchStats = async () => {
       try {
-        const res = await fetch(`${API_BASE}/analytics/customer-satisfaction`);
+        const res = await fetch(`${API_BASE}/api/analytics/customer-satisfaction`);
         if (!res.ok) return;
         const data = await res.json();
         setStats({

--- a/frontend/src/components/EmailModal.jsx
+++ b/frontend/src/components/EmailModal.jsx
@@ -8,11 +8,11 @@ export default function EmailModal({ isOpen, onClose, customer }) {
   const [body, setBody] = useState('');
 
 
-  const API_BASE = import.meta.env.VITE_API_BASE_URL || '/api';
+  const API_BASE = import.meta.env.VITE_API_BASE_URL || '';
 
   const sendEmail = async () => {
     try {
-      const res = await fetch(`${API_BASE}/emails/send`, {
+      const res = await fetch(`${API_BASE}/api/emails/send`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({

--- a/frontend/src/components/InventorySnapshot.jsx
+++ b/frontend/src/components/InventorySnapshot.jsx
@@ -82,10 +82,10 @@ export default function InventorySnapshot() {
   // const [modalParams, setModalParams] = useState(null);
 
   useEffect(() => {
-    const API_BASE = import.meta.env.PROD ? import.meta.env.VITE_API_BASE_URL : '/api';
+    const API_BASE = import.meta.env.PROD ? import.meta.env.VITE_API_BASE_URL : '';
     const fetchStats = async () => {
       try {
-        const url = `${API_BASE}/analytics/inventory-overview`;
+        const url = `${API_BASE}/api/analytics/inventory-overview`;
         console.log("API called:", url);
         const res = await fetch(url);
         if (!res.ok) {

--- a/frontend/src/components/LeadPerformanceKPI.jsx
+++ b/frontend/src/components/LeadPerformanceKPI.jsx
@@ -17,10 +17,10 @@ export default function LeadPerformanceKPI() {
   });
 
   useEffect(() => {
-    const API_BASE = import.meta.env.PROD ? import.meta.env.VITE_API_BASE_URL : '/api';
+    const API_BASE = import.meta.env.PROD ? import.meta.env.VITE_API_BASE_URL : '';
     const fetchStats = async () => {
       try {
-        const res = await fetch(`${API_BASE}/analytics/lead-overview`);
+        const res = await fetch(`${API_BASE}/api/analytics/lead-overview`);
         if (!res.ok) return;
         const data = await res.json();
         setStats({

--- a/frontend/src/components/MarketingCampaignROI.jsx
+++ b/frontend/src/components/MarketingCampaignROI.jsx
@@ -12,10 +12,10 @@ export default function MarketingCampaignROI() {
   });
 
   useEffect(() => {
-    const API_BASE = import.meta.env.PROD ? import.meta.env.VITE_API_BASE_URL : '/api';
+    const API_BASE = import.meta.env.PROD ? import.meta.env.VITE_API_BASE_URL : '';
     const fetchStats = async () => {
       try {
-        const res = await fetch(`${API_BASE}/analytics/marketing-roi`);
+        const res = await fetch(`${API_BASE}/api/analytics/marketing-roi`);
         if (!res.ok) return;
         const data = await res.json();
         setStats({

--- a/frontend/src/components/MonthlySummary.jsx
+++ b/frontend/src/components/MonthlySummary.jsx
@@ -4,10 +4,10 @@ export default function MonthlySummary() {
   const [summary, setSummary] = useState('');
 
   useEffect(() => {
-    const API_BASE = import.meta.env.PROD ? import.meta.env.VITE_API_BASE_URL : '/api';
+    const API_BASE = import.meta.env.PROD ? import.meta.env.VITE_API_BASE_URL : '';
     const fetchSummary = async () => {
       try {
-        const res = await fetch(`${API_BASE}/analytics/month-summary`);
+        const res = await fetch(`${API_BASE}/api/analytics/month-summary`);
         if (!res.ok) return;
         const data = await res.json();
         setSummary(data.summary || '');

--- a/frontend/src/components/SalesPerformanceKPI.jsx
+++ b/frontend/src/components/SalesPerformanceKPI.jsx
@@ -7,7 +7,7 @@ export default function SalesPerformanceKPI() {
   useEffect(() => {
     const fetchStats = async () => {
       try {
-        const res = await fetch(`${API_BASE}/floor-traffic/month-metrics`);
+        const res = await fetch(`${API_BASE}/api/floor-traffic/month-metrics`);
         if (!res.ok) return;
         const data = await res.json();
         const total = data.total_customers ?? data.totalCustomers ?? 0;

--- a/frontend/src/components/SalesTeamActivity.jsx
+++ b/frontend/src/components/SalesTeamActivity.jsx
@@ -11,10 +11,10 @@ export default function SalesTeamActivity() {
   });
 
   useEffect(() => {
-    const API_BASE = import.meta.env.PROD ? import.meta.env.VITE_API_BASE_URL : '/api';
+    const API_BASE = import.meta.env.PROD ? import.meta.env.VITE_API_BASE_URL : '';
     const fetchStats = async () => {
       try {
-        const res = await fetch(`${API_BASE}/analytics/sales-team-activity`);
+        const res = await fetch(`${API_BASE}/api/analytics/sales-team-activity`);
         if (!res.ok) return;
         const data = await res.json();
         setStats({

--- a/frontend/src/components/ServiceDepartmentPerformance.jsx
+++ b/frontend/src/components/ServiceDepartmentPerformance.jsx
@@ -12,10 +12,10 @@ export default function ServiceDepartmentPerformance() {
   });
 
   useEffect(() => {
-    const API_BASE = import.meta.env.PROD ? import.meta.env.VITE_API_BASE_URL : '/api';
+    const API_BASE = import.meta.env.PROD ? import.meta.env.VITE_API_BASE_URL : '';
     const fetchStats = async () => {
       try {
-        const res = await fetch(`${API_BASE}/analytics/service-performance`);
+        const res = await fetch(`${API_BASE}/api/analytics/service-performance`);
         if (!res.ok) return;
         const data = await res.json();
         setStats({

--- a/frontend/src/components/SmartSearchBar.jsx
+++ b/frontend/src/components/SmartSearchBar.jsx
@@ -4,7 +4,7 @@ import { Link } from "react-router-dom";
 import CustomerNameLink from "./CustomerNameLink";
 
 export default function SmartSearchBar() {
-  const API_BASE = import.meta.env.VITE_API_BASE_URL || '/api';
+  const API_BASE = import.meta.env.VITE_API_BASE_URL || '';
   const [query, setQuery] = useState('');
   const [results, setResults] = useState({ customers: [], inventory: [] });
   const [open, setOpen] = useState(false);
@@ -17,7 +17,7 @@ export default function SmartSearchBar() {
     }
     clearTimeout(timer.current);
     timer.current = setTimeout(() => {
-      fetch(`${API_BASE}/search?q=${encodeURIComponent(query.trim())}`)
+      fetch(`${API_BASE}/api/search?q=${encodeURIComponent(query.trim())}`)
         .then(r => (r.ok ? r.json() : Promise.reject()))
         .then(data => setResults(data))
         .catch(() => setResults({ customers: [], inventory: [] }));

--- a/frontend/src/pages/DealsPage.jsx
+++ b/frontend/src/pages/DealsPage.jsx
@@ -52,7 +52,7 @@ export default function DealsPage() {
 
   // Fetch all deals
   useEffect(() => {
-    fetch(`${API_BASE}/deals/`)
+    fetch(`${API_BASE}/api/deals/`)
       .then((res) => {
         if (!res.ok) throw new Error("Failed to load deals");
         return res.json();
@@ -63,7 +63,7 @@ export default function DealsPage() {
 
   // Fetch sold customers for dropdown
   useEffect(() => {
-    fetch(`${API_BASE}/deals/sold-customers`)
+    fetch(`${API_BASE}/api/deals/sold-customers`)
       .then((res) => {
         if (!res.ok) throw new Error("Failed to load sold customers");
         return res.json();
@@ -79,7 +79,7 @@ export default function DealsPage() {
 
   function handleUnwind(deal) {
     if (!window.confirm("Unwind this deal?")) return;
-    fetch(`${API_BASE}/deals/${deal.id}/unwind`, {
+    fetch(`${API_BASE}/api/deals/${deal.id}/unwind`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ reason: "Manager unwind from UI" }),
@@ -107,7 +107,7 @@ export default function DealsPage() {
       back_gross: parseFloat(form.back_gross.value) || 0,
       total_gross: parseFloat(form.total_gross.value) || 0,
     };
-    fetch(`${API_BASE}/deals/${selectedDeal.id}`, {
+    fetch(`${API_BASE}/api/deals/${selectedDeal.id}`, {
       method: "PATCH",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(updated),
@@ -158,7 +158,7 @@ export default function DealsPage() {
     ) {
       val = parseFloat(val) || 0;
     }
-    fetch(`${API_BASE}/deals/${editCell.id}`, {
+    fetch(`${API_BASE}/api/deals/${editCell.id}`, {
       method: "PATCH",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ [editCell.field]: val }),

--- a/frontend/src/pages/EditAppraisalPage.jsx
+++ b/frontend/src/pages/EditAppraisalPage.jsx
@@ -5,7 +5,7 @@ import toast from 'react-hot-toast';
 export default function EditAppraisalPage() {
   const { id } = useParams();
   const navigate = useNavigate();
-  const API_BASE = import.meta.env.VITE_API_BASE_URL || '/api';
+  const API_BASE = import.meta.env.VITE_API_BASE_URL || '';
 
   const [form, setForm] = useState({ vehicle_vin: '', customer_id: '' });
   const [loading, setLoading] = useState(true);
@@ -13,7 +13,7 @@ export default function EditAppraisalPage() {
   useEffect(() => {
     const fetchData = async () => {
       try {
-        const res = await fetch(`${API_BASE}/appraisals/${id}`);
+        const res = await fetch(`${API_BASE}/api/appraisals/${id}`);
         if (!res.ok) throw new Error('Failed to load');
         const data = await res.json();
         setForm({
@@ -38,7 +38,7 @@ export default function EditAppraisalPage() {
   const handleSubmit = async (e) => {
     e.preventDefault();
     try {
-      const res = await fetch(`${API_BASE}/appraisals/${id}`, {
+      const res = await fetch(`${API_BASE}/api/appraisals/${id}`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(form),

--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -21,8 +21,7 @@ export default function LoginPage() {
     setLoading(true);
     setError("");
     try {
-      // FIXED: Only append /login, NOT /api/login
-      const res = await fetch(`${API_BASE}/login`, {
+      const res = await fetch(`${API_BASE}/api/login`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(form)
@@ -50,8 +49,7 @@ export default function LoginPage() {
     setForgotSuccess("");
     setError("");
     try {
-      // FIXED: Only append /forgot-password, NOT /api/forgot-password
-      const res = await fetch(`${API_BASE}/forgot-password`, {
+      const res = await fetch(`${API_BASE}/api/forgot-password`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ email: forgotEmail })

--- a/frontend/src/routes/CustomerCard.jsx
+++ b/frontend/src/routes/CustomerCard.jsx
@@ -40,7 +40,7 @@ const ANIM_PROPS = { initial: { opacity: 0, y: 20 }, animate: { opacity: 1, y: 0
 
 export default function CustomerCard({ userRole = "sales" }) {
   const { id } = useParams()
-  const API_BASE = import.meta.env.VITE_API_BASE_URL || '/api'
+  const API_BASE = import.meta.env.VITE_API_BASE_URL || ''
   const CURRENT_USER_ID = 1
 
   const [customer, setCustomer] = useState(null)
@@ -67,7 +67,7 @@ export default function CustomerCard({ userRole = "sales" }) {
   // ---- AI Live Hotness Auto-Update ----
   const fetchHotness = async () => {
     try {
-      const res = await fetch(`${API_BASE}/customers/${id}/ai-hotness`);
+      const res = await fetch(`${API_BASE}/api/customers/${id}/ai-hotness`);
       if (res.ok) {
         const { score } = await res.json();
         setCustomer(prev => prev ? { ...prev, hotness: score } : prev);
@@ -79,7 +79,7 @@ export default function CustomerCard({ userRole = "sales" }) {
 
   const fetchCustomerData = async () => {
     try {
-      const res = await fetch(`${API_BASE}/customers/${id}`);
+      const res = await fetch(`${API_BASE}/api/customers/${id}`);
       if (res.ok) {
         const data = await res.json();
         setCustomer(data);
@@ -99,7 +99,7 @@ export default function CustomerCard({ userRole = "sales" }) {
   // ---- Next Best Action ----
   const [nextAction, setNextAction] = useState('');
   useEffect(() => {
-    fetch(`${API_BASE}/customers/${id}/ai-next-action`)
+    fetch(`${API_BASE}/api/customers/${id}/ai-next-action`)
       .then(res => res.json()).then(data => setNextAction(data.action));
   }, [id, ledger, tasks]);
 
@@ -110,14 +110,14 @@ export default function CustomerCard({ userRole = "sales" }) {
 
   useEffect(() => {
     setLoading(true)
-    fetch(`${API_BASE}/customers/${id}`)
+    fetch(`${API_BASE}/api/customers/${id}`)
       .then(r => r.json()).then(data => { setCustomer(data); setEdited(data); setLoading(false) })
       .catch(() => setLoading(false))
-    fetch(`${API_BASE}/customers/${id}/ai-summary`)
+    fetch(`${API_BASE}/api/customers/${id}/ai-summary`)
       .then(r => r.json()).then(setAiInfo)
-    fetch(`${API_BASE}/activities?customer_id=${id}`)
+    fetch(`${API_BASE}/api/activities?customer_id=${id}`)
       .then(r => r.json()).then(setLedger)
-    fetch(`${API_BASE}/customers/${id}/files`)
+    fetch(`${API_BASE}/api/customers/${id}/files`)
       .then(r => r.json()).then(docs => setFiles(docs || []))
     // Social Lookup (Mocked)
     setTimeout(() => setSocial({
@@ -140,21 +140,21 @@ export default function CustomerCard({ userRole = "sales" }) {
 
   const fetchTasks = async () => {
     try {
-      const res = await fetch(`${API_BASE}/tasks?customer_id=${id}`)
+      const res = await fetch(`${API_BASE}/api/tasks?customer_id=${id}`)
       if (res.ok) setTasks(await res.json())
       else setTasks([])
     } catch { setTasks([]) }
   }
   const fetchAppointments = async () => {
     try {
-      const res = await fetch(`${API_BASE}/appointments?customer_id=${id}`)
+      const res = await fetch(`${API_BASE}/api/appointments?customer_id=${id}`)
       if (res.ok) setAppointments(await res.json())
       else setAppointments([])
     } catch { setAppointments([]) }
   }
   const fetchDealOffers = async () => {
     try {
-      const res = await fetch(`${API_BASE}/deals?customer_id=${id}`);
+      const res = await fetch(`${API_BASE}/api/deals?customer_id=${id}`);
       if (res.ok) setDealOffers(await res.json());
       else setDealOffers([]);
     } catch { setDealOffers([]) }
@@ -163,12 +163,12 @@ export default function CustomerCard({ userRole = "sales" }) {
   const logActivity = async (type, note = '', subject = '') => {
     const payload = { activity_type: type, note, subject, customer_id: id, user_id: CURRENT_USER_ID }
     try {
-      await fetch(`${API_BASE}/activities`, {
+      await fetch(`${API_BASE}/api/activities`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(payload)
       })
-      fetch(`${API_BASE}/activities?customer_id=${id}`)
+      fetch(`${API_BASE}/api/activities?customer_id=${id}`)
         .then(r => r.json()).then(setLedger)
     } catch (err) { }
   }
@@ -178,7 +178,7 @@ export default function CustomerCard({ userRole = "sales" }) {
       const payload = {}
       PROFILE_FIELDS.forEach(({ key }) => payload[key] = edited[key] ?? "")
       if (userRole === "manager") payload['hashed_password'] = edited['hashed_password'] ?? ""
-      const res = await fetch(`${API_BASE}/customers/${id}`, {
+      const res = await fetch(`${API_BASE}/api/customers/${id}`, {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(payload)
@@ -205,13 +205,13 @@ export default function CustomerCard({ userRole = "sales" }) {
     setUploading(true)
     const form = new FormData()
     form.append("file", file)
-    const res = await fetch(`${API_BASE}/customers/${id}/files/smart`, { method: 'POST', body: form })
+    const res = await fetch(`${API_BASE}/api/customers/${id}/files/smart`, { method: 'POST', body: form })
     if (res.ok) {
       const { fields } = await res.json();
       setEdited(prev => ({ ...prev, ...fields }));
     }
     setUploading(false)
-    fetch(`${API_BASE}/customers/${id}/files`).then(r => r.json()).then(docs => setFiles(docs || []))
+    fetch(`${API_BASE}/api/customers/${id}/files`).then(r => r.json()).then(docs => setFiles(docs || []))
   }
 
   // ---- Credit Modal ----
@@ -251,7 +251,7 @@ export default function CustomerCard({ userRole = "sales" }) {
     const [due, setDue] = useState('')
     const handleAdd = async () => {
       if (!title) return
-      await fetch(`${API_BASE}/tasks`, {
+      await fetch(`${API_BASE}/api/tasks`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ title, due_date: due, customer_id: id })
@@ -278,7 +278,7 @@ export default function CustomerCard({ userRole = "sales" }) {
     const [start, setStart] = useState('')
     const handleAdd = async () => {
       if (!type || !start) return
-      await fetch(`${API_BASE}/appointments`, {
+      await fetch(`${API_BASE}/api/appointments`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ appointment_type: type, start_time: start, customer_id: id })

--- a/frontend/src/routes/CustomersPage.jsx
+++ b/frontend/src/routes/CustomersPage.jsx
@@ -10,7 +10,7 @@ import MassTextModal from '../components/MassTextModal';
 import MassEmailModal from '../components/MassEmailModal';
 
 export default function CustomersPage() {
-  const API_BASE = import.meta.env.VITE_API_BASE_URL || '/api';
+  const API_BASE = import.meta.env.VITE_API_BASE_URL || '';
   const [search, setSearch] = useState('');
   const [filters, setFilters] = useState(['All', 'Hot Leads', 'Service', 'BMW Owners', 'Equity+']);
   const [selectedFilter, setSelectedFilter] = useState('All');
@@ -51,7 +51,7 @@ export default function CustomersPage() {
 
   async function fetchCustomers() {
     try {
-      let url = `${API_BASE}/customers`;
+      let url = `${API_BASE}/api/customers`;
       const params = [];
       if (search) params.push(`q=${encodeURIComponent(search)}`);
       url += params.length ? '?' + params.join('&') : '';
@@ -77,7 +77,7 @@ export default function CustomersPage() {
   }
 
   async function handleSaveCustomer(form) {
-    await fetch(`${API_BASE}/customers`, {
+      await fetch(`${API_BASE}/api/customers`, {
       method: 'POST',
       body: JSON.stringify(form),
       headers: { 'Content-Type': 'application/json' }
@@ -88,7 +88,7 @@ export default function CustomersPage() {
 
   async function handleImport(customers) {
     await Promise.all(customers.map(c =>
-      fetch(`${API_BASE}/customers`, {
+      fetch(`${API_BASE}/api/customers`, {
         method: 'POST',
         body: JSON.stringify(c),
         headers: { 'Content-Type': 'application/json' }
@@ -112,7 +112,7 @@ export default function CustomersPage() {
   // Mass action logic
   async function handleMassTextSend(message) {
     // Example endpoint - update as needed
-    await fetch(`${API_BASE}/bulk/text`, {
+    await fetch(`${API_BASE}/api/bulk/text`, {
       method: 'POST',
       body: JSON.stringify({ ids: selected, message }),
       headers: { 'Content-Type': 'application/json' }
@@ -121,7 +121,7 @@ export default function CustomersPage() {
     clearSelection();
   }
   async function handleMassEmailSend({ subject, body }) {
-    await fetch(`${API_BASE}/bulk/email`, {
+    await fetch(`${API_BASE}/api/bulk/email`, {
       method: 'POST',
       body: JSON.stringify({ ids: selected, subject, body }),
       headers: { 'Content-Type': 'application/json' }

--- a/frontend/src/routes/LeadLog.jsx
+++ b/frontend/src/routes/LeadLog.jsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import { useCustomerCard } from '../context/CustomerCardContext';
 
 export default function LeadLog() {
-  const API_BASE = `${import.meta.env.VITE_API_BASE_URL}/leads`;
+  const API_BASE = import.meta.env.VITE_API_BASE_URL || '';
   const today = new Date().toISOString().split('T')[0];
 
   // Overlay context
@@ -36,7 +36,7 @@ export default function LeadLog() {
     const params = new URLSearchParams();
     if (startDate) params.append('startDate', startDate);
     if (endDate) params.append('endDate', endDate);
-    const url = `${API_BASE}?${params.toString()}`;
+    const url = `${API_BASE}/api/leads?${params.toString()}`;
     try {
       const res = await fetch(url);
       if (!res.ok) {
@@ -59,7 +59,7 @@ export default function LeadLog() {
 
   const fetchPrioritized = async () => {
     setPrioritizedError('');
-    const url = `${API_BASE}/prioritized`;
+    const url = `${API_BASE}/api/leads/prioritized`;
     try {
       const res = await fetch(url);
       if (!res.ok) {
@@ -82,7 +82,7 @@ export default function LeadLog() {
 
   const fetchAwaiting = async () => {
     setAwaitingError('');
-    const url = `${API_BASE}/awaiting-response`;
+    const url = `${API_BASE}/api/leads/awaiting-response`;
     try {
       const res = await fetch(url);
       if (!res.ok) {
@@ -105,7 +105,7 @@ export default function LeadLog() {
 
   const fetchMetrics = async () => {
     setMetricsError('');
-    const url = `${API_BASE}/metrics`;
+    const url = `${API_BASE}/api/leads/metrics`;
     try {
       const res = await fetch(url);
       if (!res.ok) {
@@ -133,7 +133,7 @@ export default function LeadLog() {
       setAskError('Enter a question.');
       return;
     }
-    const url = `${API_BASE}/ask`;
+    const url = `${API_BASE}/api/leads/ask`;
     const payload = { question, lead_id: leadId || null };
     try {
       const res = await fetch(url, {

--- a/frontend/src/routes/Users.jsx
+++ b/frontend/src/routes/Users.jsx
@@ -13,7 +13,7 @@ export default function Users() {
   const [saving, setSaving] = useState(false);
   const [editId, setEditId] = useState(null);
 
-  const API_BASE = import.meta.env.VITE_API_BASE_URL || "/api";
+  const API_BASE = import.meta.env.VITE_API_BASE_URL || "";
 
   useEffect(() => {
     fetchUsers();
@@ -21,7 +21,7 @@ export default function Users() {
   }, [API_BASE]);
 
   const fetchUsers = () => {
-    fetch(`${API_BASE}/users/`)
+    fetch(`${API_BASE}/api/users/`)
       .then((res) => {
         if (!res.ok) throw new Error("Failed to load users");
         return res.json();
@@ -64,7 +64,7 @@ export default function Users() {
     try {
       let res, updatedUser;
       if (editId) {
-        res = await fetch(`${API_BASE}/users/${editId}`, {
+        res = await fetch(`${API_BASE}/api/users/${editId}`, {
           method: "PUT",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify(payload),
@@ -78,7 +78,7 @@ export default function Users() {
           users.map((u) => (u.id === editId ? updatedUser : u))
         );
       } else {
-        res = await fetch(`${API_BASE}/users/`, {
+        res = await fetch(`${API_BASE}/api/users/`, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify(payload),
@@ -101,7 +101,7 @@ export default function Users() {
   const handleDelete = async (id) => {
     if (!window.confirm("Delete this user?")) return;
     try {
-      const res = await fetch(`${API_BASE}/users/${id}`, { method: "DELETE" });
+      const res = await fetch(`${API_BASE}/api/users/${id}`, { method: "DELETE" });
       if (!res.ok) throw new Error("Failed to delete user");
       setUsers((users) => users.filter((u) => u.id !== id));
     } catch (err) {

--- a/frontend/src/routes/UsersPage.jsx
+++ b/frontend/src/routes/UsersPage.jsx
@@ -4,7 +4,7 @@ import UserModal from '../components/UserModal'
 import Pagination from '../components/Pagination'
 
 export default function UsersPage() {
-  const API_BASE = import.meta.env.VITE_API_BASE_URL || '/api'
+  const API_BASE = import.meta.env.VITE_API_BASE_URL || ''
   const [users, setUsers] = useState([])
   const [filtered, setFiltered] = useState([])
   const [search, setSearch] = useState('')
@@ -29,7 +29,7 @@ export default function UsersPage() {
     setIsLoading(true)
     setError('')
     try {
-      const res = await fetch(`${API_BASE}/users/`)
+      const res = await fetch(`${API_BASE}/api/users/`)
       if (!res.ok) throw new Error('Failed to load users')
       const data = await res.json()
       setUsers(data)
@@ -54,7 +54,7 @@ export default function UsersPage() {
     setUsers(prev => prev.map(u => (u.id === user.id ? updated : u)))
     setFiltered(prev => prev.map(u => (u.id === user.id ? updated : u)))
     try {
-      const res = await fetch(`${API_BASE}/users/${user.id}`, {
+      const res = await fetch(`${API_BASE}/api/users/${user.id}`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ active: updated.active })
@@ -75,7 +75,7 @@ export default function UsersPage() {
   const handleSubmit = async data => {
     try {
       const isEdit = !!editing
-      const url = isEdit ? `${API_BASE}/users/${editing.id}` : `${API_BASE}/users/`
+      const url = isEdit ? `${API_BASE}/api/users/${editing.id}` : `${API_BASE}/api/users/`
       const method = isEdit ? 'PUT' : 'POST'
       const res = await fetch(url, {
         method,

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -17,6 +17,6 @@ export default defineConfig({
   },
   // Optional: expose your prod env var under a simpler name
   define: {
-    __API_BASE__: JSON.stringify(process.env.VITE_API_BASE_URL || '/api'),
+    __API_BASE__: JSON.stringify(process.env.VITE_API_BASE_URL || ''),
   },
 });


### PR DESCRIPTION
## Summary
- ensure API_BASE defaults to backend root and every API call uses `${API_BASE}/api/…`
- clean up duplicate or missing `/api` segments across frontend code

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_688e6333eaf8832284af3e5bce7acdaa